### PR TITLE
support custom api port setting

### DIFF
--- a/PARAMETERS.md
+++ b/PARAMETERS.md
@@ -34,6 +34,9 @@
 --cpu              [OPTIONAL] Enable or disable device cpu.
                Default value is false.
                --cpu=<true|false>
+--api_port         [OPTIONAL] miner API port.
+               Default value is 8080.
+               --api_port=8080
 ```
 
 ## AMD Settings

--- a/sources/api/api.cpp
+++ b/sources/api/api.cpp
@@ -39,7 +39,7 @@ void api::ServerAPI::loopAccept()
     namespace boost_http = boost::beast::http;
 
     boost_io_context ioContext{};
-    boost_acceptor acceptor{ ioContext, { boost_tcp::v4(), 8080 } };
+    boost_acceptor acceptor{ ioContext, { boost_tcp::v4(), castU16(port) } };
 
     while (true == alive.load(boost::memory_order::relaxed))
     {

--- a/sources/common/cli.cpp
+++ b/sources/common/cli.cpp
@@ -277,6 +277,14 @@ common::Cli::Cli()
             "[OPTIONAL] assign a pool with a coin.\n"
             "--sm_pool=COIN@POOL_URL:POOL_PORT"
         )
+
+        // api setting
+        (
+            "api_port",
+            value<uint32_t>(),
+            "[OPTIONAL] Set port of the api.\n"
+            "--api_port=8080"
+        )
         ;
 }
 

--- a/sources/common/cli.hpp
+++ b/sources/common/cli.hpp
@@ -104,5 +104,8 @@ namespace common
         bool isSmartMining() const;
         customTupleStrStr getSmartMiningWallet() const;
         customTupleStrStrU32 getSmartMiningPool() const;
+
+        // Api
+        uint32_t   getApiPort() const;
     };
 }

--- a/sources/common/cli_pool.cpp
+++ b/sources/common/cli_pool.cpp
@@ -117,3 +117,12 @@ std::optional<std::string> common::Cli::getPassword() const
     }
     return std::nullopt;
 }
+
+uint32_t common::Cli::getApiPort() const
+{
+    if (true == contains("api_port"))
+    {
+        return params["api_port"].as<uint32_t>();
+    }
+    return 8080u;
+}

--- a/sources/common/cli_pool.cpp
+++ b/sources/common/cli_pool.cpp
@@ -118,6 +118,7 @@ std::optional<std::string> common::Cli::getPassword() const
     return std::nullopt;
 }
 
+
 uint32_t common::Cli::getApiPort() const
 {
     if (true == contains("api_port"))

--- a/sources/common/config.cpp
+++ b/sources/common/config.cpp
@@ -351,6 +351,13 @@ bool common::Config::loadCli(int argc, char** argv)
                 poolConfig.password = mining.password;
             }
         }
+        
+        ////////////////////////////////////////////////////////////////////////
+        auto const ApiPort { cli.getApiPort() };
+        if (true == algo::inRange(1u, 65535u, ApiPort))
+        {
+            api.port = ApiPort;
+        }
     }
     catch(std::exception const& e)
     {

--- a/sources/common/config.hpp
+++ b/sources/common/config.hpp
@@ -59,6 +59,11 @@ namespace common
             std::string file{};
         };
 
+        struct ApiConfig
+        {
+            uint32_t port{ 8080u };
+        };
+
         common::PROFILE                profile { common::PROFILE::STANDARD };
         common::Cli                    cli{};
         LogConfig                      log{};
@@ -70,6 +75,7 @@ namespace common
         std::map<uint32_t, PoolConfig> deviceSettings{};
         PoolConfig                     amdSetting{};
         PoolConfig                     nvidiaSetting{};
+        ApiConfig                      api{}; 
 
         static Config& instance();
         bool load(int argc, char** argv);

--- a/sources/miner.cpp
+++ b/sources/miner.cpp
@@ -39,7 +39,7 @@ int main(
         }
 
         ////////////////////////////////////////////////////////////////////////
-        serverAPI.setPort(8080);
+        serverAPI.setPort(config.api.port);
         if (false == serverAPI.bind())
         {
             return 1;


### PR DESCRIPTION
This update introduces a new parameter `api_port=8080`, which replaces the fixed `8080` port of the `serverAPI` with the parameter.

https://github.com/luminousmining/miner/blob/79a4ad84ca73fca2948225dc40a102ba2e44f96c/sources/api/api.cpp#L42

The fixed api port `8080` perhaps is the default setting for HiveOS (I don't know well about HiveOS though). However, in general, the port `8080` is frequently occupied by other applications such as terminal nodes for linux systems. In this case, the system throws an error upon binding the api port, which then terminates the miner process.