### PR TITLE
support socks5 proxy through a localhost server

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -60,6 +60,21 @@ miner.exe^
  --ssl=false
 ```
 
+## [Optional] Connection via a socks5 proxy
+Requires a socks5 proxy server running on localhost. For example, the Linux [tor](https://www.torproject.org/) client runs a socks5 server on the port 9050 by default.
+```bat
+miner.exe^
+ --host="fr.vipor.net"^
+ --port=5030^
+ --wallet="YOUR_WALLET"^
+ --algo="kawpow"^
+ --workername="luminousminer"^
+ --password="x"^
+ --ssl=false
+ --socks5=true
+ --socks_port=9050
+```
+
 # SPLIT MINING
 In these examples the RIG contains more than 2 GPUs !
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -70,8 +70,8 @@ miner.exe^
  --algo="kawpow"^
  --workername="luminousminer"^
  --password="x"^
- --ssl=false
- --socks5=true
+ --ssl=false^
+ --socks5=true^
  --socks_port=9050
 ```
 

--- a/PARAMETERS.md
+++ b/PARAMETERS.md
@@ -34,10 +34,10 @@
 --cpu              [OPTIONAL] Enable or disable device cpu.
                Default value is false.
                --cpu=<true|false>
---socks5          [OPTIONAL] Enable SOCKS5 proxy.
+--socks5          [OPTIONAL] Enable pool connection through a SOCKS5 proxy server on localhost.
                Default value is false.
                --socks5=<true|false>
---socks_port      [OPTIONAL] Port of the SOCKS proxy.
+--socks_port      [OPTIONAL] The port of the SOCKS5 proxy server on localhost. Be careful not to confuse this with the `port' parameter for the pool address.
                Default value is 9050.
                --socks_port=9050
 --api_port        [OPTIONAL] miner API port.

--- a/PARAMETERS.md
+++ b/PARAMETERS.md
@@ -34,7 +34,13 @@
 --cpu              [OPTIONAL] Enable or disable device cpu.
                Default value is false.
                --cpu=<true|false>
---api_port         [OPTIONAL] miner API port.
+--socks5          [OPTIONAL] Enable SOCKS5 proxy.
+               Default value is false.
+               --socks5=<true|false>
+--socks_port      [OPTIONAL] Port of the SOCKS proxy.
+               Default value is 9050.
+               --socks_port=9050
+--api_port        [OPTIONAL] miner API port.
                Default value is 8080.
                --api_port=8080
 ```

--- a/README.md
+++ b/README.md
@@ -59,5 +59,9 @@ https://www.mdpi.com/2410-387X/7/4/60
 https://www.researchgate.net/publication/255971534_Parallel_Cloud_Computing_Exploiting_Parallelism_on_Keccak_FPGA_and_GPU_Comparison  
 https://ieeexplore.ieee.org/document/8391706  
 
+## References - Librairies
+[asio-socks45-client
+](https://github.com/sehe/asio-socks45-client) - We recognize [Seth Heeren](https://github.com/sehe) for providing the SOCKS5 client implementation.
+
 ## SAST Tools
 [PVS-Studio](https://pvs-studio.com/pvs-studio/?utm_source=website&utm_medium=github&utm_campaign=open_source) - static analyzer for C, C++, C#, and Java code.

--- a/sources/common/cli.cpp
+++ b/sources/common/cli.cpp
@@ -92,6 +92,19 @@ common::Cli::Cli()
             "Default value is false.\n"
             "--stale=<true|false>"
         )
+        (
+            "socks5",
+            value<bool>(),
+            "[OPTIONAL] Enable SOCKS5 proxy.\n"
+            "Default value is false.\n"
+            "--socks5=<true|false>."
+        )
+        (
+            "socks_port",
+            value<uint32_t>(),
+            "[OPTIONAL] Port of the SOCKS proxy.\n"
+            "--socks_port=9050"
+        )
 
         // Pool Custom
         (

--- a/sources/common/cli.hpp
+++ b/sources/common/cli.hpp
@@ -53,6 +53,7 @@ namespace common
         std::optional<std::string>   getHost() const;
         bool                         isSSL() const;
         bool                         isStale() const;
+        bool                         isSocks5() const;
         uint32_t                     getPort() const;
         std::optional<std::string>   getAlgo() const;
         std::optional<std::string>   getWallet() const;
@@ -107,5 +108,8 @@ namespace common
 
         // Api
         uint32_t   getApiPort() const;
+
+        // Socks proxy settings
+        uint32_t   getSocksPort() const;
     };
 }

--- a/sources/common/cli_pool.cpp
+++ b/sources/common/cli_pool.cpp
@@ -88,6 +88,7 @@ uint32_t common::Cli::getPort() const
     return 0u;
 }
 
+
 std::optional<std::string> common::Cli::getAlgo() const
 {
     if (true == contains("algo"))

--- a/sources/common/cli_pool.cpp
+++ b/sources/common/cli_pool.cpp
@@ -59,6 +59,16 @@ bool common::Cli::isSSL() const
 }
 
 
+bool common::Cli::isSocks5() const
+{
+    if (true == contains("socks5"))
+    {
+        return params["socks5"].as<bool>();
+    }
+    return false;
+}
+
+
 bool common::Cli::isStale() const
 {
     if (true == contains("stale"))
@@ -77,7 +87,6 @@ uint32_t common::Cli::getPort() const
     }
     return 0u;
 }
-
 
 std::optional<std::string> common::Cli::getAlgo() const
 {
@@ -126,4 +135,14 @@ uint32_t common::Cli::getApiPort() const
         return params["api_port"].as<uint32_t>();
     }
     return 8080u;
+}
+
+
+uint32_t common::Cli::getSocksPort() const
+{
+    if (true == contains("socks_port"))
+    {
+        return params["socks_port"].as<uint32_t>();
+    }
+    return 9050u;
 }

--- a/sources/common/config.cpp
+++ b/sources/common/config.cpp
@@ -139,7 +139,15 @@ bool common::Config::loadCli(int argc, char** argv)
 
         mining.secrureConnect = cli.isSSL();
         mining.stale = cli.isStale();
-
+        mining.socks5 = cli.isSocks5();
+        if (true == mining.socks5)
+        {
+            auto const SocksPort { cli.getSocksPort() };
+            if (true == algo::inRange(1u, 65535u, SocksPort))
+            {
+                mining.socksPort = SocksPort;
+            }
+        }
         ////////////////////////////////////////////////////////////////////////
         auto const ravenMinerBTCWallet{ cli.getRavenMinerBTCWallet() };
         if (std::nullopt != ravenMinerBTCWallet)

--- a/sources/common/config.cpp
+++ b/sources/common/config.cpp
@@ -148,6 +148,7 @@ bool common::Config::loadCli(int argc, char** argv)
                 mining.socksPort = SocksPort;
             }
         }
+        
         ////////////////////////////////////////////////////////////////////////
         auto const ravenMinerBTCWallet{ cli.getRavenMinerBTCWallet() };
         if (std::nullopt != ravenMinerBTCWallet)

--- a/sources/common/config.hpp
+++ b/sources/common/config.hpp
@@ -22,12 +22,14 @@ namespace common
             std::string   host{ "" };
             uint32_t      port{ 0u };
             uint32_t      retryConnectionCount{ 10 };
+            uint32_t      socksPort{ 0u };
             std::string   algo{ "" };
             std::string   workerName{ "" };
             std::string   wallet{ "" };
             std::string   password{ "x" };
             bool          secrureConnect{ false };
             bool          stale { false };
+            bool          socks5 { false };
         };
 
         struct SmartMiningConfig

--- a/sources/network/socks5.hpp
+++ b/sources/network/socks5.hpp
@@ -1,3 +1,5 @@
+// Borrowed from https://github.com/sehe/asio-socks45-client/blob/efeae8933348908768f1764f04fbe3839248bfa8/socks5.hpp
+
 #include <boost/asio.hpp>
 #include <boost/endian/arithmetic.hpp>
 

--- a/sources/network/socks5.hpp
+++ b/sources/network/socks5.hpp
@@ -1,0 +1,444 @@
+#include <boost/asio.hpp>
+#include <boost/endian/arithmetic.hpp>
+
+namespace socks5 { // threw in the kitchen sink for error codes
+#ifdef STANDALONE_ASIO
+    using std::error_category;
+    using std::error_code;
+    using std::error_condition;
+    using std::system_error;
+#else
+    namespace asio = boost::asio;
+    using boost::system::error_category;
+    using boost::system::error_code;
+    using boost::system::error_condition;
+    using boost::system::system_error;
+#endif
+
+    enum class result_code {
+        ok                         = 0,
+        invalid_version            = 1,
+        disallowed                 = 2,
+        auth_method_rejected       = 3,
+        network_unreachable        = 4,
+        host_unreachable           = 5,
+        connection_refused         = 6,
+        ttl_expired                = 7,
+        command_not_supported      = 8,
+        address_type_not_supported = 9,
+        //
+        failed = 99,
+    };
+
+    auto const& get_result_category() {
+      struct impl : error_category {
+        const char* name() const noexcept override { return "result_code"; }
+        std::string message(int ev) const override {
+          switch (static_cast<result_code>(ev)) {
+          case result_code::ok:                         return "Success";
+          case result_code::invalid_version:            return "SOCKS5 invalid reply version";
+          case result_code::disallowed:                 return "SOCKS5 disallowed";
+          case result_code::auth_method_rejected:       return "SOCKS5 no accepted authentication method";
+          case result_code::network_unreachable:        return "SOCKS5 network unreachable";
+          case result_code::host_unreachable:           return "SOCKS5 host unreachable";
+          case result_code::connection_refused:         return "SOCKS5 connection refused";
+          case result_code::ttl_expired:                return "SOCKS5 TTL expired";
+          case result_code::command_not_supported:      return "SOCKS5 command not supported";
+          case result_code::address_type_not_supported: return "SOCKS5 address type not supported";
+          case result_code::failed:                     return "SOCKS5 general unexpected failure";
+          default:                                      return "unknown error";
+          }
+        }
+        error_condition
+        default_error_condition(int ev) const noexcept override {
+            return error_condition{ev, *this};
+        }
+        bool equivalent(int ev, error_condition const& condition)
+            const noexcept override {
+            return condition.value() == ev && &condition.category() == this;
+        }
+        bool equivalent(error_code const& error,
+                        int ev) const noexcept override {
+            return error.value() == ev && &error.category() == this;
+        }
+      } const static instance;
+      return instance;
+    }
+
+    error_code make_error_code(result_code se) {
+        return error_code{
+            static_cast<std::underlying_type<result_code>::type>(se),
+            get_result_category()};
+    }
+} // namespace socks5
+
+template <>
+struct boost::system::is_error_code_enum<socks5::result_code>
+    : std::true_type {};
+
+namespace socks5 {
+    using namespace std::placeholders;
+
+    template <typename Proto> struct core_t {
+        using Endpoint = typename Proto::endpoint;
+        using Query    = typename boost::asio::ip::basic_resolver<Proto>::query;
+        Endpoint _proxy;
+
+        core_t(Query const& target, Endpoint proxy)
+            : _proxy(proxy)
+            , _request(target)
+        {
+        }
+        core_t(Endpoint const& target, Endpoint proxy)
+            : _proxy(proxy)
+            , _request(target)
+        {
+        }
+
+#pragma pack(push)
+#pragma pack(1)
+        enum class addr_type : uint8_t { IPv4 = 0x01, Domain = 0x03, IPv6 = 0x04 };
+        enum class auth_method : uint8_t {
+            none   = 0x00, // No authentication
+            gssapi = 0x01, // GSSAPI (RFC 1961
+            basic  = 0x02, // Username/password (RFC 1929)
+            // 0x03–0x7F methods assigned by IANA[11]
+            challenge_handshake = 0x03, // Challenge-Handshake Authentication Protocol
+            challenge_response = 0x05,  // Challenge-Response Authentication Method
+            ssl  = 0x06, // Secure Sockets Layer
+            nds  = 0x07, // NDS Authentication
+            maf  = 0x08, // Multi-Authentication Framework
+            json = 0x09, // JSON Parameter Block
+        };
+        enum class version : uint8_t {
+            none   = 0x00,
+            socks4 = 0x04,
+            socks5 = 0x05,
+        };
+        enum class proxy_command : uint8_t {
+            connect       = 0x01,
+            bind          = 0x02,
+            udp_associate = 0x03,
+        };
+        enum class proxy_reply : uint8_t {
+            succeeded                  = 0x00,
+            general_failure            = 0x01,
+            disallowed                 = 0x02,
+            network_unreachable        = 0x03,
+            host_unreachable           = 0x04,
+            connection_refused         = 0x05,
+            ttl_expired                = 0x06,
+            command_not_supported      = 0x07,
+            address_type_not_supported = 0x08,
+        };
+
+        using ipv4_octets = boost::asio::ip::address_v4::bytes_type;
+        using ipv6_octets = boost::asio::ip::address_v6::bytes_type;
+        using net_short   = boost::endian::big_uint16_t;
+
+        struct {
+            version     ver       = version::socks5;
+            uint8_t     nmethods  = 0x01;
+            auth_method method[1] = {auth_method::none};
+        } _greeting;
+
+        struct {
+            version reply_version;
+            uint8_t cauth;
+        } _greeting_response;
+
+        struct wire_address {
+            addr_type type{};
+            union {
+                ipv4_octets              ipv4;
+                ipv6_octets              ipv6;
+                std::array<uint8_t, 256> domain{0}; // length prefixed
+            } payload;
+
+            size_t var_length() const {
+                return sizeof(type) + payload_length();
+            }
+
+            size_t payload_length() const
+            {
+                switch (type) {
+                case addr_type::IPv4: return sizeof(payload.ipv4);
+                case addr_type::IPv6: return sizeof(payload.ipv6);
+                case addr_type::Domain:
+                    assert(payload.domain[0] < payload.domain.max_size());
+                    return 1 + payload.domain[0];
+                }
+                return 0;
+            }
+        };
+
+        struct request_t {
+            version       ver      = version::socks5;
+            proxy_command cmd      = proxy_command::connect;
+            uint8_t       reserved = 0;
+            wire_address  var_address;
+            net_short     port;
+
+            // constructors
+            request_t(Endpoint const& ep) : port(ep.port())
+            {
+                auto& addr = ep.address();
+                if (addr.is_v4()) {
+                    var_address.type         = addr_type::IPv4;
+                    var_address.payload.ipv4 = addr.to_v4().to_bytes();
+                } else {
+                    var_address.type         = addr_type::IPv6;
+                    var_address.payload.ipv6 = addr.to_v6().to_bytes();
+                }
+            }
+
+            request_t(Query const& q) : port(std::stoi(q.service_name())) {
+                std::string const domain = q.host_name();
+                var_address.type         = addr_type::Domain;
+
+                auto len = std::min(var_address.payload.domain.max_size() - 1,
+                                    domain.length());
+                assert(len == domain.length() || "domain truncated");
+                var_address.payload.domain[0] = len;
+                std::copy_n(domain.data(), len,
+                            var_address.payload.domain.data() + 1);
+            }
+
+            auto buffers() const {
+                return std::array {
+                    boost::asio::buffer(this, offsetof(request_t, var_address)),
+                    boost::asio::buffer(&var_address, var_address.var_length()),
+                    boost::asio::buffer(&port, sizeof(port)),
+                };
+            }
+        } _request;
+
+        struct response_t {
+            version      reply_version;
+            proxy_reply  reply;
+            uint8_t      reserved = 0x0;
+            wire_address var_address {addr_type::IPv4};
+            net_short    port;
+
+            auto head_buffers() {
+                return std::array{
+                    boost::asio::buffer(this, offsetof(response_t, var_address) + sizeof(addr_type)),
+                };
+            }
+
+            auto tail_buffers() { // depends on head_buffers being correctly received!
+                return std::array{
+                    boost::asio::buffer(&var_address.payload, var_address.payload_length()),
+                    boost::asio::buffer(&port, sizeof(port)),
+                };
+            }
+        } _response;
+#pragma pack(pop)
+
+        using const_buffer   = boost::asio::const_buffer;
+        using mutable_buffer = boost::asio::mutable_buffer;
+
+        auto greeting_buffers() const {
+            return boost::asio::buffer(&_greeting, sizeof(_greeting));
+        }
+
+        auto greeting_response_buffers() {
+            return boost::asio::buffer(&_greeting_response, sizeof(_greeting_response));
+        }
+
+        auto request_buffers() const { return _request.buffers(); }
+        auto response_head_buffers() { return _response.head_buffers(); }
+        auto response_tail_buffers() { return _response.tail_buffers(); }
+
+        error_code get_greeting_result(error_code ec = {}) const {
+            if (ec)
+                return ec;
+            if (_greeting_response.reply_version != version::socks5)
+                return result_code::invalid_version;
+
+            if (_greeting_response.cauth != 0) {
+                return result_code::auth_method_rejected;
+            }
+
+            return result_code::ok;
+        }
+
+        error_code get_result(error_code ec = {}) const {
+            if (ec)
+                return ec;
+            if (_response.reply_version != version::socks5)
+                return result_code::invalid_version;
+
+            switch (_response.reply) {
+            case proxy_reply::succeeded:                  return result_code::ok;
+            case proxy_reply::disallowed:                 return result_code::disallowed;
+            case proxy_reply::network_unreachable:        return result_code::network_unreachable;
+            case proxy_reply::host_unreachable:           return result_code::host_unreachable;
+            case proxy_reply::connection_refused:         return result_code::connection_refused;
+            case proxy_reply::ttl_expired:                return result_code::ttl_expired;
+            case proxy_reply::command_not_supported:      return result_code::command_not_supported;
+            case proxy_reply::address_type_not_supported: return result_code::address_type_not_supported;
+            case proxy_reply::general_failure: break;
+            }
+            return result_code::failed;
+        };
+
+    };
+
+    template <typename Socket, typename Completion>
+    struct async_proxy_connect_op {
+        using Proto         = typename Socket::protocol_type;
+        using Endpoint      = typename Proto::endpoint;
+        using executor_type = typename Socket::executor_type;
+        auto get_executor() { return _socket.get_executor(); }
+
+      private:
+        core_t<Proto> _core;
+        Socket&       _socket;
+        Completion    _handler;
+
+      public:
+        template <typename EndpointOrQuery>
+        async_proxy_connect_op(Completion handler, Socket& s,
+                               EndpointOrQuery target, Endpoint proxy)
+            : _core(target, proxy)
+            , _socket(s)
+            , _handler(std::move(handler))
+        {
+        }
+
+        using Self = std::unique_ptr<async_proxy_connect_op>;
+        void init(Self&& self) { operator()(self, INIT{}); }
+
+      private:
+        // states
+        struct INIT{};
+        struct CONNECT{};
+        struct GREETING_SENT{};
+        struct ONGREETING_RESPONSE{};
+        struct REQUEST_SENT{};
+        struct ON_RESPONSE_HEAD{};
+        struct ON_RESPONSE_TAIL{};
+
+        struct Binder {
+            Self _self;
+            template <typename... Args>
+            decltype(auto) operator()(Args&&... args) {
+                return (*_self)(_self, std::forward<Args>(args)...);
+            }
+        };
+
+        void operator()(Self& self, INIT) {
+            _socket.async_connect(_core._proxy,
+               std::bind(Binder{std::move(self)}, CONNECT{}, _1));
+        }
+
+        void operator()(Self& self, CONNECT, error_code ec) {
+            if (ec) return _handler(ec);
+            boost::asio::async_write(
+                _socket,
+                _core.greeting_buffers(),
+                std::bind(Binder{std::move(self)}, GREETING_SENT{}, _1, _2));
+        }
+
+        void operator()(Self& self, GREETING_SENT, error_code ec, size_t xfer) {
+            if (ec) return _handler(ec);
+            auto buf = _core.greeting_response_buffers();
+            boost::asio::async_read(
+                _socket, buf, boost::asio::transfer_exactly(buffer_size(buf)),
+                std::bind(Binder{std::move(self)}, ONGREETING_RESPONSE{}, _1, _2));
+        }
+
+        void operator()(Self& self, ONGREETING_RESPONSE, error_code ec, size_t xfer) {
+            ec = _core.get_greeting_result(ec);
+            if (ec) return _handler(ec);
+
+            boost::asio::async_write(
+                _socket, _core.request_buffers(),
+                std::bind(Binder{std::move(self)}, REQUEST_SENT{}, _1, _2));
+        }
+
+        void operator()(Self& self, REQUEST_SENT, error_code ec, size_t xfer) {
+            if (ec) return _handler(ec);
+            auto buf = _core.response_head_buffers();
+            boost::asio::async_read(
+                _socket, buf, boost::asio::transfer_exactly(buffer_size(buf)),
+                std::bind(Binder{std::move(self)}, ON_RESPONSE_HEAD{}, _1, _2));
+        }
+
+        void operator()(Self& self, ON_RESPONSE_HEAD, error_code ec, size_t xfer) {
+            if (ec) return _handler(ec);
+            auto buf = _core.response_tail_buffers();
+            boost::asio::async_read(
+                _socket, buf, boost::asio::transfer_exactly(buffer_size(buf)),
+                std::bind(Binder{std::move(self)}, ON_RESPONSE_TAIL{}, _1, _2));
+        }
+
+        void operator()(Self& self, ON_RESPONSE_TAIL, error_code ec, size_t xfer) {
+            _handler(_core.get_result(ec));
+        }
+    };
+
+    template <typename Socket, typename EndpointOrQuery,
+              typename Endpoint = typename Socket::protocol_type::endpoint>
+    error_code proxy_connect(Socket& s, EndpointOrQuery target, Endpoint proxy,
+                             error_code& ec)
+    {
+        core_t<typename Socket::protocol_type> core(target, proxy);
+        ec.clear();
+
+        s.connect(core._proxy, ec);
+
+        if (!ec)
+            boost::asio::write(s, core.greeting_buffers(), ec);
+
+        using boost::asio::transfer_exactly;
+        if (!ec) {
+            auto buf = core.greeting_response_buffers();
+            boost::asio::read(s, buf, transfer_exactly(buffer_size(buf)), ec);
+        }
+        ec = core.get_greeting_result(ec);
+
+        if (!ec) {
+            boost::asio::write(s, core.request_buffers(), ec);
+        }
+
+        if (!ec) {
+            auto buf = core.response_head_buffers();
+            boost::asio::read(s, buf, transfer_exactly(buffer_size(buf)), ec);
+        }
+        if (!ec) {
+            auto buf = core.response_tail_buffers();
+            boost::asio::read(s, buf, transfer_exactly(buffer_size(buf)), ec);
+        }
+
+        return ec = core.get_result(ec);
+    }
+
+    template <typename Socket, typename EndpointOrQuery,
+              typename Endpoint = typename Socket::protocol_type::endpoint>
+    void proxy_connect(Socket& s, EndpointOrQuery target, Endpoint proxy)
+    {
+        error_code ec;
+        if (proxy_connect(s, target, proxy, ec))
+            throw system_error(ec);
+    }
+
+    template <typename Socket, typename Token, typename EndpointOrQuery,
+              typename Endpoint = typename Socket::protocol_type::endpoint>
+    auto async_proxy_connect(Socket& s, EndpointOrQuery target, Endpoint proxy,
+                             Token&& token)
+    {
+        using Result = asio::async_result<std::decay_t<Token>, void(error_code)>;
+        using Completion = typename Result::completion_handler_type;
+
+        Completion completion(std::forward<Token>(token));
+        Result     result(completion);
+
+        using Op = async_proxy_connect_op<Socket, Completion>;
+        // make an owning self ptr, to serve a unique async chain
+        auto self = std::make_unique<Op>(completion, s, target, proxy);
+        self->init(std::move(self));
+        return result.get();
+    }
+} // namespace socks5


### PR DESCRIPTION
This update introduces a new feature, connecting to a pool via socks5 server in localhost (e.g., [tor proxy](https://www.torproject.org/), [ssh dynamic port forwarding](https://man.openbsd.org/ssh#D), etc.).

The feature is enabled if the parameter `socks5` is `true`, where the socks5 port is specified by the parameter `socks_port` (default is `9050`, which is the default of the tor linux client).

Rented GPU nodes (e.g., [clore.ai](https://clore.ai/)) often blocks the mining pool addresses for some reasons. In this case, the socks5 proxy is a useful solution to bypass the network blocking.

For socks5 client implementation, I borrowed a boost::asio-based client in https://github.com/sehe/asio-socks45-client. Currently, only a socks5 server on localhost without id & password authentications is supported. This suffices the use cases when tor proxy or ssh dynamic port forwarding is used (nevertheless, I believe it should not be too difficult to update codes for a more general socks5 support).