### PR TITLE
fix: out-of-bounds write in toHash256 from overlong pool hex

### DIFF
--- a/sources/algo/hash_utils.cpp
+++ b/sources/algo/hash_utils.cpp
@@ -32,33 +32,31 @@ algo::hash256 algo::toHash256(std::string const& str)
 {
     algo::hash256 hash{};
     std::string   hex{ str };
-    size_t        index{ hex.length() };
-    uint64_t      pos{ algo::LEN_HASH_256 - 1 };
+
+    // Strip an optional 0x / 0X prefix (replaces the fragile per-chunk "0x" test).
+    if (hex.size() >= 2u && hex[0] == '0' && (hex[1] == 'x' || hex[1] == 'X'))
+    {
+        hex.erase(0u, 2u);
+    }
 
     if ((hex.length() % 2) != 0)
     {
-        ++index;
         hex.push_back('0');
     }
 
-    while (index > 0u)
+    // hash256 holds LEN_HASH_256 bytes; `pos` walks down from the most-significant
+    // byte. The pool controls `str` (header/seed/boundary come straight off the
+    // wire), so bound `pos` to the buffer: any excess high bytes are ignored
+    // instead of underflowing `pos` and writing out of bounds.
+    size_t  index{ hex.length() };
+    int64_t pos{ static_cast<int64_t>(algo::LEN_HASH_256) - 1 };
+
+    while (index >= 2u && pos >= 0)
     {
-        std::string strHex;
-        strHex += hex.at(index - 2);
-        strHex += hex.at(index - 1);
+        uint8_t const bits{ castU8(std::stoul(hex.substr(index - 2u, 2u), nullptr, 16)) };
+        hash.ubytes[pos] = bits;
 
-        if (strHex != "0x")
-        {
-            unsigned long const valHex{ std::stoul(strHex, nullptr, 16) };
-            uint8_t const       bits{ castU8(valHex) };
-            hash.ubytes[pos] = bits;
-        }
-        else
-        {
-            hash.ubytes[pos] = 0;
-        }
-
-        index -= 2;
+        index -= 2u;
         --pos;
     }
 

--- a/sources/algo/tests/hash.cpp
+++ b/sources/algo/tests/hash.cpp
@@ -1,3 +1,5 @@
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include <algo/hash_utils.hpp>
@@ -180,5 +182,24 @@ TEST_F(HashTest, Hash1024)
     for (uint64_t i{ 0ull }; i < algo::LEN_HASH_1024_WORD_8; ++i)
     {
         ASSERT_EQ(hash_1.ubytes[i], hash_2.ubytes[i]) << "index " << i;
+    }
+}
+
+
+TEST_F(HashTest, Hash256OverlongInputBounded)
+{
+    // Regression guard: a malicious or MITM'd pool can send a header/seed/boundary
+    // field longer than 64 hex chars. toHash256() must stay inside the 32-byte
+    // buffer -- no out-of-bounds write / crash -- dropping the excess high bytes
+    // and keeping the low 32 bytes (i.e. the last 64 hex chars).
+    std::string const canonical{ "6f109ba5226d1e0814cdeec79f1231d1d48196b5979a6d816e3621a1ef47ad80" };
+    std::string const overlong{ "ffffffffffffffffdeadbeefdeadbeef" + canonical };
+
+    algo::hash256 const expected{ algo::toHash256(canonical) };
+    algo::hash256 const actual{ algo::toHash256(overlong) };
+
+    for (uint64_t i{ 0ull }; i < algo::LEN_HASH_256_WORD_8; ++i)
+    {
+        ASSERT_EQ(expected.ubytes[i], actual.ubytes[i]) << "index " << i;
     }
 }


### PR DESCRIPTION
## Problem
`algo::toHash256(std::string const&)` walks `pos` (a `uint64_t`) down from `LEN_HASH_256 - 1`, writing one byte per two hex chars, but the loop is bounded only by `while (index > 0u)` — there is **no lower bound on `pos`**. The sibling `toHash1024` already guards `&& pos > 0`; this overload does not.

A hex string longer than 64 chars drives `pos` below 0; `--pos` wraps to `UINT64_MAX` and `hash.ubytes[pos] = ...` writes far out of bounds.

## Impact
These values come straight off the wire from the pool via `mining.notify` (header/seed/boundary in `stratum/ethash.cpp`, `stratum/progpow.cpp`, `autolykos_v2.cpp`, `sha256.cpp`). A malicious or MITM'd pool can trigger an out-of-bounds write — memory corruption / crash.

## Fix
Bound `pos` to the buffer (same discipline as `toHash1024`) so excess high bytes are ignored instead of underflowing, and strip an optional `0x`/`0X` prefix up front (replacing the fragile per-chunk `"0x"` comparison).