### PR TITLE
fix: enforce TLS certificate chain + hostname verification

### DIFF
--- a/sources/network/network.cpp
+++ b/sources/network/network.cpp
@@ -256,6 +256,9 @@ bool network::NetworkTCPClient::doSecureConnection()
         CertCloseStore(certStore, 0);
         SSL_CTX_set_cert_store(context.native_handle(), store);
 #elif defined(__linux__)
+        // Fall back to OpenSSL's built-in default trust paths if the explicit
+        // bundle below is absent, so verification still succeeds (fail-closed).
+        context.set_default_verify_paths();
         auto certPath{ common::getEnv("SSL_CERT_FILE") };
         try
         {

--- a/sources/network/network_callback.cpp
+++ b/sources/network/network_callback.cpp
@@ -1,3 +1,5 @@
+#include <boost/asio/ssl/host_name_verification.hpp>
+
 #include <common/log/log.hpp>
 #include <network/network.hpp>
 
@@ -31,12 +33,31 @@ void network::NetworkTCPClient::asyncReceive()
 }
 
 
-bool network::NetworkTCPClient::onVerifySSL([[maybe_unused]] bool preverified, boost_verify_context& ctx)
+bool network::NetworkTCPClient::onVerifySSL(bool preverified, boost_verify_context& ctx)
 {
+    // OpenSSL's chain / expiry / CA verification must pass first. The previous
+    // implementation discarded `preverified` and returned true for any cert that
+    // merely existed, which fully bypassed TLS authentication and let a MITM
+    // present any certificate. Never override a chain failure.
+    if (false == preverified)
+    {
+        logErr() << "TLS certificate chain verification failed.";
+        return false;
+    }
+
     auto const* cert{ X509_STORE_CTX_get_current_cert(ctx.native_handle()) };
     if (nullptr == cert)
     {
-        logErr() << "Certificat is incorrect.";
+        logErr() << "TLS certificate is missing.";
+        return false;
+    }
+
+    // Ensure the leaf certificate actually matches the pool hostname; a valid
+    // certificate for a different host must not be accepted.
+    boost::asio::ssl::host_name_verification const verifier{ host };
+    if (false == verifier(preverified, ctx))
+    {
+        logErr() << "TLS certificate hostname mismatch for " << host << ".";
         return false;
     }
 


### PR DESCRIPTION
## Problem
`NetworkTCPClient::onVerifySSL` returned `true` for any certificate that merely existed — it ignored OpenSSL's `preverified` result (the parameter was `[[maybe_unused]]`) and performed no hostname check. This makes the CA store loaded in `doSecureConnection` dead code.

## Impact
TLS (`--ssl` / secure connect) provides **no authentication**: a man-in-the-middle can present any self-signed or wrong-host certificate and it is accepted. Pool traffic, including share submission, can be transparently intercepted or redirected.

## Fix
- Honor `preverified` — never accept a cert that failed chain/expiry/CA validation.
- Verify the leaf certificate matches the pool hostname via `boost::asio::ssl::host_name_verification`.
- Add `set_default_verify_paths()` on Linux so the now-enforced check fails **closed** without breaking pools when the explicit CA bundle is absent.