### PR TITLE
fix: cap extranonce length to prevent integer-underflow OOM

### DIFF
--- a/sources/stratum/stratum.cpp
+++ b/sources/stratum/stratum.cpp
@@ -279,13 +279,20 @@ void stratum::Stratum::ethGetWork()
 
 void stratum::Stratum::setExtraNonce(std::string const& paramExtraNonce)
 {
-    jobInfo.extraNonceSize = castU32(paramExtraNonce.size());
-    jobInfo.extraNonce = std::strtoull(paramExtraNonce.c_str(), nullptr, 16);
+    // The pool controls this string (subscribe result / mining.set_extranonce).
+    // A 64-bit nonce is at most 16 hex chars; cap it so `16 - size()` below
+    // cannot underflow size_t and drive the fill loops into a multi-exabyte
+    // string append (remote OOM / denial of service).
+    std::string const extraNonce{ paramExtraNonce.size() > 16u ? paramExtraNonce.substr(0u, 16u)
+                                                               : paramExtraNonce };
+
+    jobInfo.extraNonceSize = castU32(extraNonce.size());
+    jobInfo.extraNonce = std::strtoull(extraNonce.c_str(), nullptr, 16);
 
     // Define the 0 counter to define nonce gap.
-    size_t      fill{ 16ull - paramExtraNonce.size() };
+    size_t      fill{ 16ull - extraNonce.size() };
     std::string extraNonceFill{};
-    extraNonceFill.assign(paramExtraNonce);
+    extraNonceFill.assign(extraNonce);
     for (size_t i{ 0ull }; i < fill; ++i)
     {
         extraNonceFill += '0';


### PR DESCRIPTION
## Problem
`Stratum::setExtraNonce` computes `size_t fill = 16ull - paramExtraNonce.size()`. The extranonce is pool-controlled (subscribe result and `mining.set_extranonce`). A string longer than 16 chars underflows `fill` to ~1.8e19, and the two subsequent loops then try to append exabytes to a `std::string`.

## Impact
A single packet from a malicious pool causes `std::bad_alloc` / OOM termination — a remote denial of service.

## Fix
Cap the untrusted extranonce at 16 hex chars (the width of a 64-bit nonce) before the subtraction.