### PR TITLE
fix: use-after-free in asynchronous send buffer

### DIFF
--- a/sources/network/network.cpp
+++ b/sources/network/network.cpp
@@ -347,27 +347,25 @@ void network::NetworkTCPClient::send(char const* data, size_t size)
         return;
     }
 
+    // async_write does NOT copy the buffer it is given: the storage must stay
+    // valid until the operation completes. Callers pass pointers to temporaries
+    // (e.g. send(boost_json) hands over a local string's c_str()), so the data
+    // was being freed before the write finished -- a use-after-free. Own a copy
+    // for the lifetime of the async op by capturing it in the completion handler.
+    // shared_ptr (not unique_ptr) keeps the handler copyable: async_write is a
+    // composed operation that may copy the handler through its internal layers,
+    // and a captured unique_ptr would make the lambda move-only.
+    auto payload{ std::make_shared<std::string>(data, size) };
+    auto handler{ [this, payload](boost_error_code const& ec, std::size_t bytes)
+                  { onSend(ec, bytes); } };
+
     if (true == secureConnection)
     {
-        boost::asio::async_write(
-            *socketTCP,
-            boost::asio::buffer(data, size),
-            boost::bind(
-                &NetworkTCPClient::onSend,
-                this,
-                boost::asio::placeholders::error,
-                boost::asio::placeholders::bytes_transferred));
+        boost::asio::async_write(*socketTCP, boost::asio::buffer(*payload), std::move(handler));
     }
     else
     {
-        boost::asio::async_write(
-            socketTCP->next_layer(),
-            boost::asio::buffer(data, size),
-            boost::bind(
-                &NetworkTCPClient::onSend,
-                this,
-                boost::asio::placeholders::error,
-                boost::asio::placeholders::bytes_transferred));
+        boost::asio::async_write(socketTCP->next_layer(), boost::asio::buffer(*payload), std::move(handler));
     }
 }
 


### PR DESCRIPTION
## Problem
`send(boost_json const&)` builds a local `std::string` and passes its `c_str()` to `send(char const*, size_t)`, which hands the raw pointer to `boost::asio::async_write`. `async_write` does **not** copy the buffer — it must stay valid until completion — but the local string is destroyed as soon as `send` returns.

## Impact
The asynchronous write reads freed memory (use-after-free): it can corrupt outgoing Stratum frames or crash. It currently works only by timing luck.

## Fix
Copy the payload into a `std::shared_ptr<std::string>` captured by the completion handler so the bytes outlive the operation.

> Note: serializing concurrent writes on a single stream (the declared-but-unused lock-free `tx` queue) is a separate, pre-existing concern left for a follow-up.