### PR TITLE
fix: always authorize after mining.subscribe (NiceHash EthereumStratum)

### DIFF
--- a/sources/stratum/ethash.cpp
+++ b/sources/stratum/ethash.cpp
@@ -20,9 +20,8 @@ void stratum::StratumEthash::onResponse(boost::json::object const& root)
         {
             if (false == root.contains("error") || true == root.at("error").is_null())
             {
-                if (true == root.contains("result") && true == root.at("result").is_array())
+                if (stratum::STRATUM_TYPE::ETHEREUM_V1 == stratumType)
                 {
-                    boost::json::array const& result{ root.at("result").as_array() };
                     // NiceHash (EthereumStratum/1.0.0) returns the extranonce as the
                     // second element of "result": [["mining.notify", id, proto], nonce].
                     // Parse it defensively: a missing/short/oddly-typed result must NOT
@@ -30,17 +29,35 @@ void stratum::StratumEthash::onResponse(boost::json::object const& root)
                     // reached after result.at(1) succeeded, so any parse hiccup left the
                     // worker unauthenticated and the pool rejected every share (NiceHash
                     // reports that as "Missing KYC/KYB").
-                    if (result.size() >= 2u && true == result.at(1).is_string())
+                    if (   true == root.contains("result")
+                        && true == root.at("result").is_array())
+                    {
+                        boost::json::array const& result{ root.at("result").as_array() };
+                        if (result.size() >= 2u && true == result.at(1).is_string())
+                        {
+                            std::string const extraNonceStr{ result.at(1).as_string().c_str() };
+                            setExtraNonce(extraNonceStr);
+                            jobInfo.targetBits = std::strtoul(extraNonceStr.c_str(), nullptr, 16);
+                        }
+                    }
+                    // Always authorize on a non-error subscribe reply, even if the
+                    // extranonce could not be parsed -- skipping it leaves the worker
+                    // unauthenticated and the pool rejects every share.
+                    miningAuthorize();
+                }
+                else
+                {
+                    // Other stratum types keep the original ordering: authorize only
+                    // after the extranonce has been parsed.
+                    boost::json::array const& result{ root.at("result").as_array() };
+                    if (false == result.empty())
                     {
                         std::string const extraNonceStr{ result.at(1).as_string().c_str() };
                         setExtraNonce(extraNonceStr);
                         jobInfo.targetBits = std::strtoul(extraNonceStr.c_str(), nullptr, 16);
+                        miningAuthorize();
                     }
                 }
-                // Always authorize on a non-error subscribe reply, even if the
-                // extranonce could not be parsed -- skipping it leaves the worker
-                // unauthenticated and the pool rejects every share.
-                miningAuthorize();
             }
             else
             {

--- a/sources/stratum/ethash.cpp
+++ b/sources/stratum/ethash.cpp
@@ -20,15 +20,27 @@ void stratum::StratumEthash::onResponse(boost::json::object const& root)
         {
             if (false == root.contains("error") || true == root.at("error").is_null())
             {
-                auto result{ root.at("result").as_array() };
-                if (false == result.empty())
+                if (true == root.contains("result") && true == root.at("result").is_array())
                 {
-                    std::string extraNonceStr{ result.at(1).as_string().c_str() };
-                    setExtraNonce(extraNonceStr);
-                    jobInfo.targetBits = std::strtoul(extraNonceStr.c_str(), nullptr, 16);
-                    ;
-                    miningAuthorize();
+                    boost::json::array const& result{ root.at("result").as_array() };
+                    // NiceHash (EthereumStratum/1.0.0) returns the extranonce as the
+                    // second element of "result": [["mining.notify", id, proto], nonce].
+                    // Parse it defensively: a missing/short/oddly-typed result must NOT
+                    // prevent us from authorizing. Previously miningAuthorize() was only
+                    // reached after result.at(1) succeeded, so any parse hiccup left the
+                    // worker unauthenticated and the pool rejected every share (NiceHash
+                    // reports that as "Missing KYC/KYB").
+                    if (result.size() >= 2u && true == result.at(1).is_string())
+                    {
+                        std::string const extraNonceStr{ result.at(1).as_string().c_str() };
+                        setExtraNonce(extraNonceStr);
+                        jobInfo.targetBits = std::strtoul(extraNonceStr.c_str(), nullptr, 16);
+                    }
                 }
+                // Always authorize on a non-error subscribe reply, even if the
+                // extranonce could not be parsed -- skipping it leaves the worker
+                // unauthenticated and the pool rejects every share.
+                miningAuthorize();
             }
             else
             {


### PR DESCRIPTION
## Problem
In `StratumEthash::onResponse`, the `ID_MINING_SUBSCRIBE` handler only called `miningAuthorize()` **inside** the extranonce-parse block. NiceHash's `EthereumStratum/1.0.0` returns the extranonce as `result[1]` of a nested array; any hiccup reading `result.at(1)` (wrong shape / short array → out-of-range) skipped authorize entirely.

## Impact
The worker stays unauthenticated, so the pool rejects **every** share. On NiceHash this surfaces as the misleading `Missing KYC/KYB` message. Reproduced live mining daggerhashimoto on NiceHash.

## Fix
Parse the subscribe reply defensively (require `result` to be an array of size ≥ 2 with a string at index 1) and **always** call `miningAuthorize()` regardless of extranonce parse outcome. Also handle a non-null `error` explicitly.