### PR TITLE
fix: stack buffer overflow in decimalToHash from pool-controlled input

### DIFF
--- a/sources/algo/hash_utils.hpp
+++ b/sources/algo/hash_utils.hpp
@@ -168,6 +168,24 @@ namespace algo
         ////////////////////////////////////////////////////////////////////////
         T hash{};
 
+        // `input` is pool-controlled (e.g. the Autolykos boundary arrives in
+        // mining.notify params[6] straight off the wire). Reject anything that is
+        // not a plain decimal string: a non-digit byte makes `input[i] - '0'`
+        // below evaluate to a huge limb (a high-bit char is negative as signed
+        // `char`), which overflows the fixed-size `accs`/`ts` carry arrays.
+        for (char const c : input)
+        {
+            if (c < '0' || c > '9')
+            {
+                logErr() << "decimalToHash: rejecting non-decimal pool input";
+                return hash;
+            }
+        }
+
+        // Number of base-16 limbs. The carry loops below must never index past
+        // this; `LIMBS` is reused to size the arrays and to bound `ip`.
+        constexpr std::size_t LIMBS{ sizeof(T) + 10u };
+
         uint32_t const lenght{ castU32(input.size()) };
         uint32_t*      fs{ NEW_ARRAY(uint32_t, lenght) };
         if (nullptr == fs) [[unlikely]]
@@ -175,8 +193,8 @@ namespace algo
             return hash;
         }
 
-        uint32_t ts[sizeof(T) + 10]{ 1u };
-        uint32_t accs[sizeof(T) + 10]{ 0u };
+        uint32_t ts[LIMBS]{ 1u };
+        uint32_t accs[LIMBS]{ 0u };
 
         uint32_t tmp;
         uint32_t rem;
@@ -203,6 +221,14 @@ namespace algo
 
                 do
                 {
+                    // Stop before the carry can run off the end of `accs`; an
+                    // over-long decimal would otherwise smash the stack. The high
+                    // limbs are simply dropped (a malicious oversized boundary is
+                    // rejected later by isValidJob), never written out of bounds.
+                    if (ip + 1u >= LIMBS) [[unlikely]]
+                    {
+                        break;
+                    }
                     rem = tmp >> 4;
                     accs[ip++] = tmp - (rem << 4);
                     accs[ip] += rem;
@@ -223,6 +249,10 @@ namespace algo
 
                 do
                 {
+                    if (ip + 1u >= LIMBS) [[unlikely]]
+                    {
+                        break;
+                    }
                     rem = tmp >> 4;
                     ts[ip++] = tmp - (rem << 4);
                     ts[ip] += rem;

--- a/sources/algo/tests/hash.cpp
+++ b/sources/algo/tests/hash.cpp
@@ -210,3 +210,69 @@ TEST_F(HashTest, Hash256OverlongInputBounded)
         ASSERT_EQ(expected.ubytes[i], actual.ubytes[i]) << "index " << i;
     }
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
+// decimalToHash<hash512> turns a decimal boundary string into a hash512 whose
+// bytes are the ASCII uppercase-hex digits of the value, big-endian (most
+// significant digit at ubytes[0]). The input is pool-controlled, so these tests
+// pin both the happy path and the two attack shapes the overflow fix guards
+// against (see fix/decimaltohash-overflow).
+static std::string decimalHashToHex(algo::hash512 const& hash)
+{
+    std::string str;
+    str.reserve(sizeof(algo::hash512));
+    for (uint32_t i{ 0u }; i < sizeof(algo::hash512); ++i)
+    {
+        str.push_back(cast8(hash.ubytes[i]));
+    }
+    return str;
+}
+
+
+TEST_F(HashTest, decimalToHashValidBoundary)
+{
+    // Small values verified by hand plus the real 256-bit Autolykos boundary
+    // used by the autolykos_v2 stratum/resolver tests. Correct conversion must
+    // be preserved by the input-validation fix.
+    EXPECT_EQ("00000000000000000000000000000000000000000000000000000000000000FF",
+              decimalHashToHex(algo::decimalToHash<algo::hash512>("255")));
+
+    EXPECT_EQ("00000000000000000000000000000000000000000000000000000000499602D2",
+              decimalHashToHex(algo::decimalToHash<algo::hash512>("1234567890")));
+
+    EXPECT_EQ("0000000112E0BE826D694B2E62D01511F12A60609E6058143D609A1A1444A664",
+              decimalHashToHex(algo::decimalToHash<algo::hash512>(
+                  "28948022309329048855892746252171976963209391069768726095651290785380")));
+}
+
+
+TEST_F(HashTest, decimalToHashRejectsNonDecimal)
+{
+    // A non-digit byte (here a letter) must be rejected cleanly, returning the
+    // zero hash instead of feeding a garbage limb into the carry arrays.
+    algo::hash512 const fromLetter{ algo::decimalToHash<algo::hash512>("12345x67890") };
+    EXPECT_TRUE(algo::isHashEmpty(fromLetter));
+
+    // A high-bit byte is negative as a signed char, so `input[i] - '0'` would
+    // otherwise produce a huge limb; it must be rejected the same way.
+    std::string highBit{ "1234" };
+    highBit.push_back(cast8(0xFF));
+    algo::hash512 const fromHighBit{ algo::decimalToHash<algo::hash512>(highBit) };
+    EXPECT_TRUE(algo::isHashEmpty(fromHighBit));
+}
+
+
+TEST_F(HashTest, decimalToHashOversizedIsBounded)
+{
+    // A boundary far larger than the 256-bit field (100 decimal digits ~= 332
+    // bits). An oversized number must be handled without corrupting the stack:
+    // the carry index is bounded to LIMBS so the high limbs are dropped instead
+    // of being written past the fixed-size `accs`/`ts` arrays. The call must
+    // return cleanly and the least-significant nibble must still be correct
+    // (a run of 100 nines is == 15 mod 16).
+    std::string const oversized(100u, '9');
+    algo::hash512 const hash{ algo::decimalToHash<algo::hash512>(oversized) };
+
+    EXPECT_EQ('F', cast8(hash.ubytes[sizeof(algo::hash512) - 1u]));
+}


### PR DESCRIPTION
## Problem

`algo::decimalToHash<T>` (`sources/algo/hash_utils.hpp`) converts a decimal
string into base-16 limbs using two fixed-size **stack** arrays,
`ts[sizeof(T) + 10]` and `accs[sizeof(T) + 10]`.

The input string is pool-controlled. For Autolykos it is the boundary delivered
straight off the wire in `mining.notify`:

```cpp
// sources/stratum/autolykos_v2.cpp
jobInfo.boundary = algo::toHash2<algo::hash256, algo::hash512>(
    algo::toLittleEndian<algo::hash512>(
        algo::decimalToHash<algo::hash512>(params.at(6).as_string().c_str())));
```

Two unchecked assumptions let a malicious pool corrupt the stack:

1. `castU32(input[i] - '0')` is applied to every byte with no validation. A
   non-digit byte (e.g. a high-bit char, which is negative as signed `char`)
   produces a huge limb that blows up the carry propagation.
2. The carry loops do `accs[ip++]` / `ts[ip++]` with **no upper bound** on `ip`,
   so a sufficiently large number (or the inflated limbs above) walks past the
   end of the arrays.

The result is a remotely triggered **stack buffer overflow**. Unlike the JSON
parse paths, this is pure arithmetic with raw array writes — it does **not**
throw, so it is not contained by the `onReceive` try/catch.

## Fix

- Reject non-decimal input up front (`c < '0' || c > '9'`).
- Hoist the array size to `constexpr std::size_t LIMBS{ sizeof(T) + 10u }` and
  bound the carry index: `if (ip + 1u >= LIMBS) break;` in both carry loops,
  truncating the high limbs instead of writing out of bounds.

Valid 256-bit boundaries use far fewer than `LIMBS` limbs, so legitimate jobs
are unaffected.
