### PR TITLE
fix(amd): build the whole DAG when the driver clamps the launch (RDNA4 ethash)

### DIFF
--- a/.github/workflows/unit_test_linux.yml
+++ b/.github/workflows/unit_test_linux.yml
@@ -35,6 +35,7 @@ jobs:
         Kiss.*:
         MathTest.*:
         RotateByteTest.*:
+        StratumEthashSubmitNonce.*:
         StratumProgpowSeed.*
 
     steps:

--- a/sources/algo/ethash/opencl/ethash_dag.cl
+++ b/sources/algo/ethash/opencl/ethash_dag.cl
@@ -33,12 +33,17 @@ void ethash_build_dag(
     uint const cache_number_item)
 {
     ////////////////////////////////////////////////////////////////////////////
-    uint const dag_index = get_global_id(0) + get_global_id(1) * GROUP_SIZE;
-    if (dag_index >= dag_number_item)
+    // Grid-stride over every DAG page. Some drivers (e.g. AMD on gfx1201/RDNA4)
+    // silently execute fewer work-groups than requested when a launch dimension is
+    // very large, leaving most of a big DAG (multi-GB ethash epochs) unwritten and
+    // zero. Striding by the real launch size makes coverage independent of how many
+    // work-items actually run. The host also caps the launch so it is fully
+    // dispatched (see resolver buildDAG).
+    uint const grid_stride = (uint)(get_global_size(0) * get_global_size(1));
+    for (uint dag_index = (uint)(get_global_id(0) + get_global_id(1) * get_global_size(0));
+         dag_index < dag_number_item;
+         dag_index += grid_stride)
     {
-        return;
-    }
-
     ////////////////////////////////////////////////////////////////////////////
     __attribute__((opencl_unroll_hint))
     for (uchar loop = 0; loop < 2; ++loop)
@@ -87,5 +92,6 @@ void ethash_build_dag(
             dag[gap_index + x] = item[x];
         }
 
+    }
     }
 }

--- a/sources/algo/ethash/opencl/ethash_dag.cl
+++ b/sources/algo/ethash/opencl/ethash_dag.cl
@@ -44,54 +44,58 @@ void ethash_build_dag(
          dag_index < dag_number_item;
          dag_index += grid_stride)
     {
-    ////////////////////////////////////////////////////////////////////////////
-    __attribute__((opencl_unroll_hint))
-    for (uchar loop = 0; loop < 2; ++loop)
-    {
         ////////////////////////////////////////////////////////////////////////
-        uint const cache_start_index = (dag_index * 2u) + loop;
-        uint const cache_index = (cache_start_index % cache_number_item) * 4u;
-
-        ////////////////////////////////////////////////////////////////////////
-        uint4 item[4];
         __attribute__((opencl_unroll_hint))
-        for (uchar i = 0; i < 4; ++i)
+        for (uchar loop = 0; loop < 2; ++loop)
         {
-            uint const index_tmp = cache_index + i;
-            item[i] = cache[index_tmp];
-        }
-        item[0].x ^= cache_start_index;
+            ////////////////////////////////////////////////////////////////////
+            uint const cache_start_index = (dag_index * 2u) + loop;
+            uint const cache_index = (cache_start_index % cache_number_item) * 4u;
 
-        ////////////////////////////////////////////////////////////////////////
-        keccak_f1600(item);
-
-        ////////////////////////////////////////////////////////////////////////
-        uint k = 0;
-        __attribute__((opencl_unroll_hint))
-        for (uchar i = 0; i < DAG_LOOP; ++i)
-        {
+            ////////////////////////////////////////////////////////////////////
+            uint4 item[4];
             __attribute__((opencl_unroll_hint))
-            for (uchar j = 0; j < 4u; ++j)
+            for (uchar i = 0; i < 4; ++i)
             {
-                build_item_mix(cache, item, cache_number_item, fnv1_u32(cache_start_index ^ k,        item[j & 3u].x));
-                build_item_mix(cache, item, cache_number_item, fnv1_u32(cache_start_index ^ (k + 1u), item[j & 3u].y));
-                build_item_mix(cache, item, cache_number_item, fnv1_u32(cache_start_index ^ (k + 2u), item[j & 3u].z));
-                build_item_mix(cache, item, cache_number_item, fnv1_u32(cache_start_index ^ (k + 3u), item[j & 3u].w));
-                k += 4u;
+                uint const index_tmp = cache_index + i;
+                item[i] = cache[index_tmp];
             }
+            item[0].x ^= cache_start_index;
+
+            ////////////////////////////////////////////////////////////////////
+            keccak_f1600(item);
+
+            ////////////////////////////////////////////////////////////////////
+            uint k = 0;
+            __attribute__((opencl_unroll_hint))
+            for (uchar i = 0; i < DAG_LOOP; ++i)
+            {
+                __attribute__((opencl_unroll_hint))
+                for (uchar j = 0; j < 4u; ++j)
+                {
+                    build_item_mix(cache, item, cache_number_item,
+                        fnv1_u32(cache_start_index ^ k, item[j & 3u].x));
+                    build_item_mix(cache, item, cache_number_item,
+                        fnv1_u32(cache_start_index ^ (k + 1u), item[j & 3u].y));
+                    build_item_mix(cache, item, cache_number_item,
+                        fnv1_u32(cache_start_index ^ (k + 2u), item[j & 3u].z));
+                    build_item_mix(cache, item, cache_number_item,
+                        fnv1_u32(cache_start_index ^ (k + 3u), item[j & 3u].w));
+                    k += 4u;
+                }
+            }
+
+            ////////////////////////////////////////////////////////////////////
+            keccak_f1600(item);
+
+            ////////////////////////////////////////////////////////////////////
+            uint const gap_index = (dag_index * 8u) + (loop * 4);
+            __attribute__((opencl_unroll_hint))
+            for (uint x = 0u; x < 4u; ++x)
+            {
+                dag[gap_index + x] = item[x];
+            }
+
         }
-
-        ////////////////////////////////////////////////////////////////////////
-        keccak_f1600(item);
-
-        ////////////////////////////////////////////////////////////////////////
-        uint const gap_index = (dag_index * 8u) + (loop * 4);
-        __attribute__((opencl_unroll_hint))
-        for (uint x = 0u; x < 4u; ++x)
-        {
-            dag[gap_index + x] = item[x];
-        }
-
-    }
     }
 }

--- a/sources/common/mocker/stratum.hpp
+++ b/sources/common/mocker/stratum.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include <stratum/stratum.hpp>
 
 
@@ -9,9 +11,10 @@ namespace common
     {
         struct MockerStratum : public stratum::Stratum
         {
-            uint32_t            id{ 0u };
-            boost::json::array  paramSubmit{};
-            boost::json::object paramSubmitObject{};
+            uint32_t                        id{ 0u };
+            boost::json::array              paramSubmit{};
+            boost::json::object             paramSubmitObject{};
+            std::vector<boost::json::array> allSubmits{};
 
             inline void onResponse(boost::json::object const&) final
             {
@@ -21,6 +24,7 @@ namespace common
             {
                 id = deviceID;
                 paramSubmit = params;
+                allSubmits.push_back(params);
             }
 
             inline void miningSubmit(uint32_t const deviceID, boost::json::object const& params) final

--- a/sources/resolver/amd/ethash.cpp
+++ b/sources/resolver/amd/ethash.cpp
@@ -259,9 +259,18 @@ bool resolver::ResolverAmdEthash::buildDAG()
     OPENCL_ER(clKernel.setArg(4u, castU32(context.lightCache.numberItem)));
 
     ////////////////////////////////////////////////////////////////////////////
-    // Run kernel to build DAG
+    // Run kernel to build DAG.
+    // Cap the Y dimension so the whole launch is actually dispatched: some drivers
+    // (AMD on gfx1201/RDNA4) silently execute fewer work-groups than requested when
+    // a dimension is very large, which leaves most of a multi-GB DAG zero. The
+    // kernel grid-strides, so a capped launch still covers every page.
     uint32_t const maxGroupSize{ getMaxGroupSize() };
-    uint32_t const threadKernel{ castU32(context.dagCache.numberItem) / maxGroupSize };
+    uint32_t const maxThreadKernel{ 32768u };
+    uint32_t       threadKernel{ (castU32(context.dagCache.numberItem) + maxGroupSize - 1u) / maxGroupSize };
+    if (threadKernel > maxThreadKernel)
+    {
+        threadKernel = maxThreadKernel;
+    }
     OPENCL_ER(clQueue[currentIndexStream]->enqueueNDRangeKernel(
         clKernel,
         cl::NullRange,

--- a/sources/resolver/amd/ethash.cpp
+++ b/sources/resolver/amd/ethash.cpp
@@ -260,21 +260,28 @@ bool resolver::ResolverAmdEthash::buildDAG()
 
     ////////////////////////////////////////////////////////////////////////////
     // Run kernel to build DAG.
-    // Cap the Y dimension so the whole launch is actually dispatched: some drivers
-    // (AMD on gfx1201/RDNA4) silently execute fewer work-groups than requested when
-    // a dimension is very large, which leaves most of a multi-GB DAG zero. The
-    // kernel grid-strides, so a capped launch still covers every page.
-    uint32_t const maxGroupSize{ getMaxGroupSize() };
-    uint32_t const maxThreadKernel{ 32768u };
-    uint32_t       threadKernel{ (castU32(context.dagCache.numberItem) + maxGroupSize - 1u) / maxGroupSize };
-    if (threadKernel > maxThreadKernel)
+    // The build kernel grid-strides over the DAG (for (i = gid; i < numberItem;
+    // i += stride)), so coverage is complete for any launch of at least one
+    // work-group. We cap the work-group count (the NDRange Y dimension) because
+    // some drivers (AMD on gfx1201/RDNA4) silently dispatch fewer work-groups than
+    // requested when a dimension is very large, which leaves most of a multi-GB
+    // DAG zero. MAX_BUILD_GROUPS is therefore a ceiling, not a tuning constant: it
+    // only has to stay below that silent-clamp threshold while still saturating the
+    // CUs. 32768 groups (~8M work-items) is already orders of magnitude above the
+    // simultaneous occupancy of any current GPU, so it saturates every model; the
+    // build is DRAM-bandwidth bound, so a larger or per-device value would not
+    // change throughput.
+    constexpr uint32_t MAX_BUILD_GROUPS{ 32768u };
+    uint32_t const     maxGroupSize{ getMaxGroupSize() };
+    uint32_t           buildGroups{ (castU32(context.dagCache.numberItem) + maxGroupSize - 1u) / maxGroupSize };
+    if (buildGroups > MAX_BUILD_GROUPS)
     {
-        threadKernel = maxThreadKernel;
+        buildGroups = MAX_BUILD_GROUPS;
     }
     OPENCL_ER(clQueue[currentIndexStream]->enqueueNDRangeKernel(
         clKernel,
         cl::NullRange,
-        cl::NDRange(maxGroupSize, threadKernel, 1),
+        cl::NDRange(maxGroupSize, buildGroups, 1),
         cl::NDRange(maxGroupSize, 1, 1)));
     OPENCL_ER(clQueue[currentIndexStream]->finish());
 

--- a/sources/resolver/amd/progpow.cpp
+++ b/sources/resolver/amd/progpow.cpp
@@ -262,9 +262,18 @@ bool resolver::ResolverAmdProgPOW::buildDAG()
     OPENCL_ER(clKernel.setArg(4u, castU32(context.lightCache.numberItem)));
 
     ////////////////////////////////////////////////////////////////////////////
-    // Run kernel to build DAG
+    // Run kernel to build DAG.
+    // Cap the Y dimension so the whole launch is actually dispatched: some drivers
+    // (AMD on gfx1201/RDNA4) silently execute fewer work-groups than requested when
+    // a dimension is very large, which leaves most of a multi-GB DAG zero. The
+    // kernel grid-strides, so a capped launch still covers every page.
     uint32_t const maxGroupSize{ getMaxGroupSize() };
-    uint32_t const threadKernel{ castU32(context.dagCache.numberItem) / maxGroupSize };
+    uint32_t const maxThreadKernel{ 32768u };
+    uint32_t       threadKernel{ (castU32(context.dagCache.numberItem) + maxGroupSize - 1u) / maxGroupSize };
+    if (threadKernel > maxThreadKernel)
+    {
+        threadKernel = maxThreadKernel;
+    }
     OPENCL_ER(clQueue[currentIndexStream]->enqueueNDRangeKernel(
         clKernel,
         cl::NullRange,

--- a/sources/resolver/amd/progpow.cpp
+++ b/sources/resolver/amd/progpow.cpp
@@ -263,21 +263,28 @@ bool resolver::ResolverAmdProgPOW::buildDAG()
 
     ////////////////////////////////////////////////////////////////////////////
     // Run kernel to build DAG.
-    // Cap the Y dimension so the whole launch is actually dispatched: some drivers
-    // (AMD on gfx1201/RDNA4) silently execute fewer work-groups than requested when
-    // a dimension is very large, which leaves most of a multi-GB DAG zero. The
-    // kernel grid-strides, so a capped launch still covers every page.
-    uint32_t const maxGroupSize{ getMaxGroupSize() };
-    uint32_t const maxThreadKernel{ 32768u };
-    uint32_t       threadKernel{ (castU32(context.dagCache.numberItem) + maxGroupSize - 1u) / maxGroupSize };
-    if (threadKernel > maxThreadKernel)
+    // The build kernel grid-strides over the DAG (for (i = gid; i < numberItem;
+    // i += stride)), so coverage is complete for any launch of at least one
+    // work-group. We cap the work-group count (the NDRange Y dimension) because
+    // some drivers (AMD on gfx1201/RDNA4) silently dispatch fewer work-groups than
+    // requested when a dimension is very large, which leaves most of a multi-GB
+    // DAG zero. MAX_BUILD_GROUPS is therefore a ceiling, not a tuning constant: it
+    // only has to stay below that silent-clamp threshold while still saturating the
+    // CUs. 32768 groups (~8M work-items) is already orders of magnitude above the
+    // simultaneous occupancy of any current GPU, so it saturates every model; the
+    // build is DRAM-bandwidth bound, so a larger or per-device value would not
+    // change throughput.
+    constexpr uint32_t MAX_BUILD_GROUPS{ 32768u };
+    uint32_t const     maxGroupSize{ getMaxGroupSize() };
+    uint32_t           buildGroups{ (castU32(context.dagCache.numberItem) + maxGroupSize - 1u) / maxGroupSize };
+    if (buildGroups > MAX_BUILD_GROUPS)
     {
-        threadKernel = maxThreadKernel;
+        buildGroups = MAX_BUILD_GROUPS;
     }
     OPENCL_ER(clQueue[currentIndexStream]->enqueueNDRangeKernel(
         clKernel,
         cl::NullRange,
-        cl::NDRange(maxGroupSize, threadKernel, 1),
+        cl::NDRange(maxGroupSize, buildGroups, 1),
         cl::NDRange(maxGroupSize, 1, 1)));
     OPENCL_ER(clQueue[currentIndexStream]->finish());
 

--- a/sources/resolver/amd/tests/firopow.cpp
+++ b/sources/resolver/amd/tests/firopow.cpp
@@ -84,7 +84,7 @@ TEST_F(ResolverFiropowAmdTest, findNonce)
 TEST_F(ResolverFiropowAmdTest, notFindNonce)
 {
     initializeJob(0x85f22c9b3cd2f123);
-    jobInfo.boundaryU64 = 1ull;  // unsatisfiable boundary -> no share can clear it
+    jobInfo.boundaryU64 = 1ull; // unsatisfiable boundary -> no share can clear it
 
     ASSERT_TRUE(resolver.updateMemory(jobInfo));
     ASSERT_TRUE(resolver.updateConstants(jobInfo));
@@ -112,15 +112,15 @@ namespace resolver::test
         char const* const       expectedNonce,
         char const* const       expectedMix)
     {
-        t.jobInfo.nonce       = nonce;
+        t.jobInfo.nonce = nonce;
         t.jobInfo.blockNumber = blockNumber;
-        t.jobInfo.headerHash  = algo::toHash256(headerHashHex);
-        t.jobInfo.boundary    = algo::toHash256(boundaryHex);
+        t.jobInfo.headerHash = algo::toHash256(headerHashHex);
+        t.jobInfo.boundary = algo::toHash256(boundaryHex);
         t.jobInfo.boundaryU64 = algo::toUINT64(t.jobInfo.boundary);
         // Derive the epoch from the block number, as production does
         // (StratumProgPOW::deriveEpoch), instead of hand-feeding it.
-        t.jobInfo.epoch       = cast32(blockNumber / algo::firopow::EPOCH_LENGTH);
-        t.jobInfo.period      = t.jobInfo.blockNumber / algo::firopow::MAX_PERIOD;
+        t.jobInfo.epoch = cast32(blockNumber / algo::firopow::EPOCH_LENGTH);
+        t.jobInfo.period = t.jobInfo.blockNumber / algo::firopow::MAX_PERIOD;
 
         ASSERT_TRUE(t.resolver.updateMemory(t.jobInfo));
         ASSERT_TRUE(t.resolver.updateConstants(t.jobInfo));
@@ -149,7 +149,7 @@ namespace resolver::test
 using resolver::test::checkFiroVector;
 
 
-TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVector)  // block 1, epoch 0
+TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVector) // block 1, epoch 0
 {
     checkFiroVector(
         *this,
@@ -162,7 +162,7 @@ TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVector)  // block 1, epoch 0
 }
 
 
-TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch1)  // block 1300, epoch 1
+TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch1) // block 1300, epoch 1
 {
     checkFiroVector(
         *this,
@@ -175,7 +175,7 @@ TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch1)  // block 1300,
 }
 
 
-TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch10)  // block 13000, epoch 10
+TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch10) // block 13000, epoch 10
 {
     checkFiroVector(
         *this,
@@ -193,7 +193,7 @@ TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch10)  // block 1300
 // silently clamps the build launch at ~2^24 pages, leaving most of a multi-GB DAG
 // zero, so the digest was self-consistent but wrong (epoch 0/1/10 with smaller
 // DAGs passed; this and the live Firo epoch failed). Without the fix this fails.
-TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch419)  // block 545860
+TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch419) // block 545860
 {
     checkFiroVector(
         *this,

--- a/sources/resolver/amd/tests/firopow.cpp
+++ b/sources/resolver/amd/tests/firopow.cpp
@@ -45,8 +45,9 @@ struct ResolverFiropowAmdTest : public testing::Test
     }
 
     // Authoritative FiroPoW vector (firoorg/firo firopow_test_vectors.hpp),
-    // block 1 / epoch 0. Low epoch keeps the DAG small and the hash correct
-    // (see the DISABLED epoch-419 test for the known large-DAG defect).
+    // block 1. The epoch is derived from the block number, as in production
+    // (StratumProgPOW::deriveEpoch), rather than hand-fed: block 1 / 1300 -> epoch 0
+    // keeps the DAG small. The epoch-419 test below exercises the large-DAG path.
     void initializeJob(uint64_t const nonce)
     {
         jobInfo.nonce = nonce;
@@ -54,7 +55,7 @@ struct ResolverFiropowAmdTest : public testing::Test
         jobInfo.headerHash = algo::toHash256("2d794e900dcad779e658de9078d9a88eee87d75f7b09a8fdd270d3a8e76650c7");
         jobInfo.boundary = algo::toHash256("0001869e7a058e2aaf266cd2f166fb85c98d651e60eadbbe72bb0a36f8802805");
         jobInfo.boundaryU64 = algo::toUINT64(jobInfo.boundary);
-        jobInfo.epoch = 0;
+        jobInfo.epoch = static_cast<int32_t>(jobInfo.blockNumber / algo::firopow::EPOCH_LENGTH);
         jobInfo.period = jobInfo.blockNumber / algo::firopow::MAX_PERIOD;
     }
 };
@@ -66,7 +67,7 @@ TEST_F(ResolverFiropowAmdTest, findNonce)
 
     ASSERT_TRUE(resolver.updateMemory(jobInfo));
     ASSERT_TRUE(resolver.updateConstants(jobInfo));
-    // One workgroup starting at the vector nonce -> deterministic single result.
+    // One work-group (16 nonces / 256 lanes) at the vector nonce -> deterministic result.
     resolver.setThreads(1u);
     ASSERT_TRUE(resolver.executeSync(jobInfo));
     resolver.submit(&stratum);
@@ -100,13 +101,12 @@ TEST_F(ResolverFiropowAmdTest, notFindNonce)
 // only check that the nonce is found; a wrong-but-self-consistent digest would
 // still pass them yet be rejected live as "Invalid Firo Mixhash". These pin the
 // digest itself, across epochs (epoch 0 does not exercise DAG growth/seed).
-namespace
+namespace resolver::test
 {
     void checkFiroVector(
         ResolverFiropowAmdTest& t,
         uint64_t const          nonce,
         uint64_t const          blockNumber,
-        uint32_t const          epoch,
         char const* const       headerHashHex,
         char const* const       boundaryHex,
         char const* const       expectedNonce,
@@ -117,13 +117,15 @@ namespace
         t.jobInfo.headerHash  = algo::toHash256(headerHashHex);
         t.jobInfo.boundary    = algo::toHash256(boundaryHex);
         t.jobInfo.boundaryU64 = algo::toUINT64(t.jobInfo.boundary);
-        t.jobInfo.epoch       = static_cast<int32_t>(epoch);
+        // Derive the epoch from the block number, as production does
+        // (StratumProgPOW::deriveEpoch), instead of hand-feeding it.
+        t.jobInfo.epoch       = static_cast<int32_t>(blockNumber / algo::firopow::EPOCH_LENGTH);
         t.jobInfo.period      = t.jobInfo.blockNumber / algo::firopow::MAX_PERIOD;
 
         ASSERT_TRUE(t.resolver.updateMemory(t.jobInfo));
         ASSERT_TRUE(t.resolver.updateConstants(t.jobInfo));
-        // One workgroup (256 nonces) starting at the vector nonce: the vector nonce
-        // is computed and essentially nothing else clears the boundary.
+        // One work-group (16 nonces / 256 lanes) starting at the vector nonce: the
+        // vector nonce is computed and essentially nothing else clears the boundary.
         t.resolver.setThreads(1u);
         ASSERT_TRUE(t.resolver.executeSync(t.jobInfo));
         t.resolver.submit(&t.stratum);
@@ -144,9 +146,15 @@ namespace
 }
 
 
+using resolver::test::checkFiroVector;
+
+
 TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVector)  // block 1, epoch 0
 {
-    checkFiroVector(*this, 0x85f22c9b3cd2f123ull, 1ull, 0,
+    checkFiroVector(
+        *this,
+        0x85f22c9b3cd2f123ull,
+        1ull,
         "2d794e900dcad779e658de9078d9a88eee87d75f7b09a8fdd270d3a8e76650c7",
         "0001869e7a058e2aaf266cd2f166fb85c98d651e60eadbbe72bb0a36f8802805",
         "0x85f22c9b3cd2f123",
@@ -156,7 +164,10 @@ TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVector)  // block 1, epoch 0
 
 TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch1)  // block 1300, epoch 1
 {
-    checkFiroVector(*this, 0xdec25420bac29b01ull, 1300ull, 1,
+    checkFiroVector(
+        *this,
+        0xdec25420bac29b01ull,
+        1300ull,
         "1fc36bd5d1bff8d134e24a997cfa43cbb2a0b956379bdc0c8df444f2553f6b7d",
         "00030d3cf40b1c555e4cd9a5e2cdf70b931aca3cc1d5b77ce576146df100500a",
         "0xdec25420bac29b01",
@@ -166,7 +177,10 @@ TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch1)  // block 1300,
 
 TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch10)  // block 13000, epoch 10
 {
-    checkFiroVector(*this, 0x10d0835970ff1254ull, 13000ull, 10,
+    checkFiroVector(
+        *this,
+        0x10d0835970ff1254ull,
+        13000ull,
         "794688e6167995f4891124d488365df76becfd2fc47c5c8337c9a545801d8e60",
         "0001e84617ccaeb80f88c38f5fa4985fb9a2434e6dd31586e7f5a404cd315b1d",
         "0x10d0835970ff1254",
@@ -181,7 +195,10 @@ TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch10)  // block 1300
 // DAGs passed; this and the live Firo epoch failed). Without the fix this fails.
 TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch419)  // block 545860
 {
-    checkFiroVector(*this, 0x844c83fd15ddbc98ull, 545860ull, 419,
+    checkFiroVector(
+        *this,
+        0x844c83fd15ddbc98ull,
+        545860ull,
         "421ecabe666b8a4b3c5d9f899a15115f1fc8e2644468459c9f200d2dd10c204c",
         "00004e1fb2011c6ef320e5a5fc1b76807358965ce1ccf5fcc5dda026cd038963",
         "0x844c83fd15ddbc98",

--- a/sources/resolver/amd/tests/firopow.cpp
+++ b/sources/resolver/amd/tests/firopow.cpp
@@ -44,16 +44,17 @@ struct ResolverFiropowAmdTest : public testing::Test
         properties.clQueue = nullptr;
     }
 
+    // Authoritative FiroPoW vector (firoorg/firo firopow_test_vectors.hpp),
+    // block 1 / epoch 0. Low epoch keeps the DAG small and the hash correct
+    // (see the DISABLED epoch-419 test for the known large-DAG defect).
     void initializeJob(uint64_t const nonce)
     {
         jobInfo.nonce = nonce;
-        jobInfo.blockNumber = 544860ull;
-        jobInfo.headerHash = algo::toHash256("23bb6340c5ffcf05c3e2b86503a636b805f7ca6c93d50315971b26b72f461790");
-        jobInfo.seedHash = algo::toHash256("ac88bf0324754ae04cffe412accbbd72e534acd928bdcbe95239f660667ae26d");
-        jobInfo.boundary = algo::toHash256("00000003fffc0000000000000000000000000000000000000000000000000000");
+        jobInfo.blockNumber = 1ull;
+        jobInfo.headerHash = algo::toHash256("2d794e900dcad779e658de9078d9a88eee87d75f7b09a8fdd270d3a8e76650c7");
+        jobInfo.boundary = algo::toHash256("0001869e7a058e2aaf266cd2f166fb85c98d651e60eadbbe72bb0a36f8802805");
         jobInfo.boundaryU64 = algo::toUINT64(jobInfo.boundary);
-        jobInfo.epoch =
-            algo::ethash::ContextGenerator::instance().findEpoch(jobInfo.seedHash, algo::firopow::EPOCH_LENGTH);
+        jobInfo.epoch = 0;
         jobInfo.period = jobInfo.blockNumber / algo::firopow::MAX_PERIOD;
     }
 };
@@ -61,10 +62,12 @@ struct ResolverFiropowAmdTest : public testing::Test
 
 TEST_F(ResolverFiropowAmdTest, findNonce)
 {
-    initializeJob(0x0000315900f3f0b8);
+    initializeJob(0x85f22c9b3cd2f123);
 
     ASSERT_TRUE(resolver.updateMemory(jobInfo));
     ASSERT_TRUE(resolver.updateConstants(jobInfo));
+    // One workgroup starting at the vector nonce -> deterministic single result.
+    resolver.setThreads(1u);
     ASSERT_TRUE(resolver.executeSync(jobInfo));
     resolver.submit(&stratum);
 
@@ -73,18 +76,114 @@ TEST_F(ResolverFiropowAmdTest, findNonce)
     std::string const nonceStr{ stratum.paramSubmit[1].as_string().c_str() };
 
     using namespace std::string_literals;
-    EXPECT_EQ("0x0000315900f3f0b8"s, nonceStr);
+    EXPECT_EQ("0x85f22c9b3cd2f123"s, nonceStr);
 }
 
 
 TEST_F(ResolverFiropowAmdTest, notFindNonce)
 {
-    initializeJob(0x000100000704757f);
+    initializeJob(0x85f22c9b3cd2f123);
+    jobInfo.boundaryU64 = 1ull;  // unsatisfiable boundary -> no share can clear it
 
     ASSERT_TRUE(resolver.updateMemory(jobInfo));
     ASSERT_TRUE(resolver.updateConstants(jobInfo));
+    resolver.setThreads(1u);
     ASSERT_TRUE(resolver.executeSync(jobInfo));
     resolver.submit(&stratum);
 
     EXPECT_TRUE(stratum.paramSubmit.empty());
+}
+
+
+// Verifies the *submitted mixhash* against authoritative FiroPoW test vectors
+// (firoorg/firo: src/crypto/progpow/firopow_test_vectors.hpp). The existing tests
+// only check that the nonce is found; a wrong-but-self-consistent digest would
+// still pass them yet be rejected live as "Invalid Firo Mixhash". These pin the
+// digest itself, across epochs (epoch 0 does not exercise DAG growth/seed).
+namespace
+{
+    void checkFiroVector(
+        ResolverFiropowAmdTest& t,
+        uint64_t const          nonce,
+        uint64_t const          blockNumber,
+        uint32_t const          epoch,
+        char const* const       headerHashHex,
+        char const* const       boundaryHex,
+        char const* const       expectedNonce,
+        char const* const       expectedMix)
+    {
+        t.jobInfo.nonce       = nonce;
+        t.jobInfo.blockNumber = blockNumber;
+        t.jobInfo.headerHash  = algo::toHash256(headerHashHex);
+        t.jobInfo.boundary    = algo::toHash256(boundaryHex);
+        t.jobInfo.boundaryU64 = algo::toUINT64(t.jobInfo.boundary);
+        t.jobInfo.epoch       = static_cast<int32_t>(epoch);
+        t.jobInfo.period      = t.jobInfo.blockNumber / algo::firopow::MAX_PERIOD;
+
+        ASSERT_TRUE(t.resolver.updateMemory(t.jobInfo));
+        ASSERT_TRUE(t.resolver.updateConstants(t.jobInfo));
+        // One workgroup (256 nonces) starting at the vector nonce: the vector nonce
+        // is computed and essentially nothing else clears the boundary.
+        t.resolver.setThreads(1u);
+        ASSERT_TRUE(t.resolver.executeSync(t.jobInfo));
+        t.resolver.submit(&t.stratum);
+
+        ASSERT_FALSE(t.stratum.allSubmits.empty()) << "no share cleared boundary (wrong hash?)";
+
+        bool found{ false };
+        for (auto const& params : t.stratum.allSubmits)
+        {
+            if (std::string(expectedNonce) == std::string(params[1].as_string().c_str()))
+            {
+                found = true;
+                EXPECT_EQ(std::string(expectedMix), std::string(params[2].as_string().c_str()));
+            }
+        }
+        EXPECT_TRUE(found) << "vector nonce was not among submitted shares";
+    }
+}
+
+
+TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVector)  // block 1, epoch 0
+{
+    checkFiroVector(*this, 0x85f22c9b3cd2f123ull, 1ull, 0,
+        "2d794e900dcad779e658de9078d9a88eee87d75f7b09a8fdd270d3a8e76650c7",
+        "0001869e7a058e2aaf266cd2f166fb85c98d651e60eadbbe72bb0a36f8802805",
+        "0x85f22c9b3cd2f123",
+        "0xcfab3766331d6c4e6913e6688a71e4c26b7f36c1581cdbec0f5b19db8956eb50");
+}
+
+
+TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch1)  // block 1300, epoch 1
+{
+    checkFiroVector(*this, 0xdec25420bac29b01ull, 1300ull, 1,
+        "1fc36bd5d1bff8d134e24a997cfa43cbb2a0b956379bdc0c8df444f2553f6b7d",
+        "00030d3cf40b1c555e4cd9a5e2cdf70b931aca3cc1d5b77ce576146df100500a",
+        "0xdec25420bac29b01",
+        "0x5f8fe6069efb88d9af861999973b3523295d3b1ec7e8423c965f33b3d12b20b1");
+}
+
+
+TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch10)  // block 13000, epoch 10
+{
+    checkFiroVector(*this, 0x10d0835970ff1254ull, 13000ull, 10,
+        "794688e6167995f4891124d488365df76becfd2fc47c5c8337c9a545801d8e60",
+        "0001e84617ccaeb80f88c38f5fa4985fb9a2434e6dd31586e7f5a404cd315b1d",
+        "0x10d0835970ff1254",
+        "0x653b09240717ddc1d251e75cd24b5fb35d7890a08be6e2ac6b97105f0ff5b27d");
+}
+
+
+// block 545860 -> epoch 419, the regime real Firo blocks live in (~5 GB DAG).
+// Regression test for the grid-stride DAG-build fix: the AMD gfx1201/RDNA4 driver
+// silently clamps the build launch at ~2^24 pages, leaving most of a multi-GB DAG
+// zero, so the digest was self-consistent but wrong (epoch 0/1/10 with smaller
+// DAGs passed; this and the live Firo epoch failed). Without the fix this fails.
+TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch419)  // block 545860
+{
+    checkFiroVector(*this, 0x844c83fd15ddbc98ull, 545860ull, 419,
+        "421ecabe666b8a4b3c5d9f899a15115f1fc8e2644468459c9f200d2dd10c204c",
+        "00004e1fb2011c6ef320e5a5fc1b76807358965ce1ccf5fcc5dda026cd038963",
+        "0x844c83fd15ddbc98",
+        "0x19b62e800a00b6ad8208eb53baeebe9d5e96018ccc7df2ebe35cac463984ea4b");
 }

--- a/sources/resolver/amd/tests/firopow.cpp
+++ b/sources/resolver/amd/tests/firopow.cpp
@@ -55,7 +55,7 @@ struct ResolverFiropowAmdTest : public testing::Test
         jobInfo.headerHash = algo::toHash256("2d794e900dcad779e658de9078d9a88eee87d75f7b09a8fdd270d3a8e76650c7");
         jobInfo.boundary = algo::toHash256("0001869e7a058e2aaf266cd2f166fb85c98d651e60eadbbe72bb0a36f8802805");
         jobInfo.boundaryU64 = algo::toUINT64(jobInfo.boundary);
-        jobInfo.epoch = static_cast<int32_t>(jobInfo.blockNumber / algo::firopow::EPOCH_LENGTH);
+        jobInfo.epoch = cast32(jobInfo.blockNumber / algo::firopow::EPOCH_LENGTH);
         jobInfo.period = jobInfo.blockNumber / algo::firopow::MAX_PERIOD;
     }
 };
@@ -119,7 +119,7 @@ namespace resolver::test
         t.jobInfo.boundaryU64 = algo::toUINT64(t.jobInfo.boundary);
         // Derive the epoch from the block number, as production does
         // (StratumProgPOW::deriveEpoch), instead of hand-feeding it.
-        t.jobInfo.epoch       = static_cast<int32_t>(blockNumber / algo::firopow::EPOCH_LENGTH);
+        t.jobInfo.epoch       = cast32(blockNumber / algo::firopow::EPOCH_LENGTH);
         t.jobInfo.period      = t.jobInfo.blockNumber / algo::firopow::MAX_PERIOD;
 
         ASSERT_TRUE(t.resolver.updateMemory(t.jobInfo));

--- a/sources/resolver/amd/tests/firopow.cpp
+++ b/sources/resolver/amd/tests/firopow.cpp
@@ -146,12 +146,9 @@ namespace resolver::test
 }
 
 
-using resolver::test::checkFiroVector;
-
-
 TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVector) // block 1, epoch 0
 {
-    checkFiroVector(
+    resolver::test::checkFiroVector(
         *this,
         0x85f22c9b3cd2f123ull,
         1ull,
@@ -164,7 +161,7 @@ TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVector) // block 1, epoch 0
 
 TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch1) // block 1300, epoch 1
 {
-    checkFiroVector(
+    resolver::test::checkFiroVector(
         *this,
         0xdec25420bac29b01ull,
         1300ull,
@@ -177,7 +174,7 @@ TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch1) // block 1300, 
 
 TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch10) // block 13000, epoch 10
 {
-    checkFiroVector(
+    resolver::test::checkFiroVector(
         *this,
         0x10d0835970ff1254ull,
         13000ull,
@@ -195,7 +192,7 @@ TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch10) // block 13000
 // DAGs passed; this and the live Firo epoch failed). Without the fix this fails.
 TEST_F(ResolverFiropowAmdTest, submitMixMatchesFiroVectorEpoch419) // block 545860
 {
-    checkFiroVector(
+    resolver::test::checkFiroVector(
         *this,
         0x844c83fd15ddbc98ull,
         545860ull,

--- a/sources/stratum/tests/ethash_submit_nonce.cpp
+++ b/sources/stratum/tests/ethash_submit_nonce.cpp
@@ -1,0 +1,143 @@
+#include <cstdint>
+#include <cstdlib>
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <stratum/ethash.hpp>
+#include <stratum/stratum_type.hpp>
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Regression guard for the NiceHash EthereumStratum/1.0.0 (daggerhashimoto)
+// nonce convention. See the spec:
+//   https://github.com/nicehash/Specifications/blob/master/
+//       EthereumStratum_NiceHash_v1.0.0.txt
+//
+// The pool assigns an extranonce that occupies the HIGH bytes of the 64-bit
+// nonce; the miner owns the remaining low bytes (the "minernonce"). mining.submit
+// sends the minernonce ONLY -- no "0x" prefix, width == 8 - extranonceBytes:
+//
+//   "Second parameter of params array is job ID, third parameter is minernonce.
+//    Note ... minernonce is 6 bytes, because provided extranonce was 2 bytes.
+//    If pool provides 3 bytes extranonce, then minernonce must be 5 bytes."
+//
+// A previous bug report claimed this submit string was "malformed" (missing the
+// 0x / extranonce prefix the kawpow/progpow path uses) and proposed emitting the
+// absolute extranonce-prefixed nonce instead. That is WRONG for ethash: those
+// minernonce-only submits are exactly what NiceHash accepts. These tests lock the
+// convention so it is not "fixed" back into a rejection. The worked values below
+// are taken verbatim from the spec's own example (section III/IV):
+//
+//   extranonce = "a2eea0"  (3 bytes)
+//   minernonce = "cfae7df760"  (5 bytes, submitted as-is, no 0x)
+//   full nonce = 0xa2eea0cfae7df760
+////////////////////////////////////////////////////////////////////////////////
+
+
+namespace
+{
+    constexpr uint64_t SPEC_FULL_NONCE{ 0xa2eea0cfae7df760ull };
+    constexpr char     SPEC_EXTRA_NONCE[]{ "a2eea0" };
+    constexpr char     SPEC_MINER_NONCE[]{ "cfae7df760" };
+
+
+    // Mirror of resolver::ResolverAmdEthash::submit(): the found nonce is printed
+    // as lower-case hex and the leading extranonce hex chars are dropped to leave
+    // the minernonce that goes into mining.submit params[2].
+    std::string toMinerNonce(uint64_t const nonce, uint32_t const extraNonceSize)
+    {
+        std::stringstream nonceHexa;
+        nonceHexa << std::hex << nonce;
+        return nonceHexa.str().substr(extraNonceSize);
+    }
+}
+
+
+struct StratumEthashSubmitNonceTest : public testing::Test
+{
+    StratumEthashSubmitNonceTest() = default;
+    ~StratumEthashSubmitNonceTest() override = default;
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+// setExtraNonce() places the pool extranonce in the HIGH bytes of the search
+// start nonce and records its hex width. This is what the resolver hashes, so it
+// must carry the extranonce -- otherwise the pool recomputes a different hash.
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(StratumEthashSubmitNonceTest, ExtraNonceOccupiesHighBytesOfStartNonce)
+{
+    stratum::StratumEthash stratum{};
+    stratum.stratumType = stratum::STRATUM_TYPE::ETHEREUM_V1;
+
+    stratum.setExtraNonce(SPEC_EXTRA_NONCE);
+
+    // "a2eea0" right-padded with zeros to 16 hex chars -> 0xa2eea00000000000.
+    EXPECT_EQ(6u, stratum.jobInfo.extraNonceSize);
+    EXPECT_EQ(0xa2eea00000000000ull, stratum.jobInfo.startNonce);
+    EXPECT_EQ(stratum.jobInfo.startNonce, stratum.jobInfo.nonce);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Gluing the pool extranonce (high) with the miner's minernonce (low) must
+// reconstruct the absolute 64-bit nonce the pool verifies.
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(StratumEthashSubmitNonceTest, StartNonceGluedWithMinerNonceIsAbsoluteNonce)
+{
+    stratum::StratumEthash stratum{};
+    stratum.stratumType = stratum::STRATUM_TYPE::ETHEREUM_V1;
+
+    stratum.setExtraNonce(SPEC_EXTRA_NONCE);
+
+    uint64_t const minerNonceBits{ std::strtoull(SPEC_MINER_NONCE, nullptr, 16) };
+    EXPECT_EQ(SPEC_FULL_NONCE, stratum.jobInfo.startNonce | minerNonceBits);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// The submitted minernonce is the absolute nonce with the extranonce prefix
+// stripped: lower-case hex, NO "0x", width == 16 - extraNonceSize hex chars
+// (i.e. 8 - extranonceBytes). Matches the spec's mining.submit params[2].
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(StratumEthashSubmitNonceTest, MinerNonceIsSuffixOnlyWithoutHexPrefix)
+{
+    stratum::StratumEthash stratum{};
+    stratum.stratumType = stratum::STRATUM_TYPE::ETHEREUM_V1;
+
+    stratum.setExtraNonce(SPEC_EXTRA_NONCE);
+
+    std::string const minerNonce{ toMinerNonce(SPEC_FULL_NONCE, stratum.jobInfo.extraNonceSize) };
+
+    EXPECT_EQ(SPEC_MINER_NONCE, minerNonce);
+    EXPECT_EQ(16u - stratum.jobInfo.extraNonceSize, minerNonce.size());
+    EXPECT_EQ(std::string::npos, minerNonce.find("0x"));
+    EXPECT_EQ(std::string::npos, minerNonce.find('x'));
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Minernonce width tracks the extranonce width: a 3-byte extranonce leaves a
+// 5-byte (10 hex) minernonce; a 2-byte extranonce leaves a 6-byte (12 hex) one.
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(StratumEthashSubmitNonceTest, MinerNonceWidthTracksExtraNonceWidth)
+{
+    {
+        stratum::StratumEthash stratum{};
+        stratum.stratumType = stratum::STRATUM_TYPE::ETHEREUM_V1;
+        stratum.setExtraNonce("a2eea0"); // 3 bytes
+        EXPECT_EQ(10u, 16u - stratum.jobInfo.extraNonceSize);
+    }
+    {
+        stratum::StratumEthash stratum{};
+        stratum.stratumType = stratum::STRATUM_TYPE::ETHEREUM_V1;
+        stratum.setExtraNonce("bf04"); // 2 bytes
+        EXPECT_EQ(12u, 16u - stratum.jobInfo.extraNonceSize);
+    }
+}

--- a/sources/stratum/tests/ethash_submit_nonce.cpp
+++ b/sources/stratum/tests/ethash_submit_nonce.cpp
@@ -67,7 +67,6 @@ struct StratumEthashSubmitNonceTest : public testing::Test
 // start nonce and records its hex width. This is what the resolver hashes, so it
 // must carry the extranonce -- otherwise the pool recomputes a different hash.
 ////////////////////////////////////////////////////////////////////////////////
-
 TEST_F(StratumEthashSubmitNonceTest, ExtraNonceOccupiesHighBytesOfStartNonce)
 {
     stratum::StratumEthash stratum{};
@@ -86,7 +85,6 @@ TEST_F(StratumEthashSubmitNonceTest, ExtraNonceOccupiesHighBytesOfStartNonce)
 // Gluing the pool extranonce (high) with the miner's minernonce (low) must
 // reconstruct the absolute 64-bit nonce the pool verifies.
 ////////////////////////////////////////////////////////////////////////////////
-
 TEST_F(StratumEthashSubmitNonceTest, StartNonceGluedWithMinerNonceIsAbsoluteNonce)
 {
     stratum::StratumEthash stratum{};
@@ -104,7 +102,6 @@ TEST_F(StratumEthashSubmitNonceTest, StartNonceGluedWithMinerNonceIsAbsoluteNonc
 // stripped: lower-case hex, NO "0x", width == 16 - extraNonceSize hex chars
 // (i.e. 8 - extranonceBytes). Matches the spec's mining.submit params[2].
 ////////////////////////////////////////////////////////////////////////////////
-
 TEST_F(StratumEthashSubmitNonceTest, MinerNonceIsSuffixOnlyWithoutHexPrefix)
 {
     stratum::StratumEthash stratum{};
@@ -125,7 +122,6 @@ TEST_F(StratumEthashSubmitNonceTest, MinerNonceIsSuffixOnlyWithoutHexPrefix)
 // Minernonce width tracks the extranonce width: a 3-byte extranonce leaves a
 // 5-byte (10 hex) minernonce; a 2-byte extranonce leaves a 6-byte (12 hex) one.
 ////////////////////////////////////////////////////////////////////////////////
-
 TEST_F(StratumEthashSubmitNonceTest, MinerNonceWidthTracksExtraNonceWidth)
 {
     {

--- a/sources/stratum/tests/ethash_submit_nonce.cpp
+++ b/sources/stratum/tests/ethash_submit_nonce.cpp
@@ -36,29 +36,26 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 
-namespace
+constexpr uint64_t SPEC_FULL_NONCE{ 0xa2eea0cfae7df760ull };
+constexpr char     SPEC_EXTRA_NONCE[]{ "a2eea0" };
+constexpr char     SPEC_MINER_NONCE[]{ "cfae7df760" };
+
+
+// Mirror of resolver::ResolverAmdEthash::submit(): the found nonce is printed
+// as lower-case hex and the leading extranonce hex chars are dropped to leave
+// the minernonce that goes into mining.submit params[2].
+static std::string toMinerNonce(uint64_t const nonce, uint32_t const extraNonceSize)
 {
-    constexpr uint64_t SPEC_FULL_NONCE{ 0xa2eea0cfae7df760ull };
-    constexpr char     SPEC_EXTRA_NONCE[]{ "a2eea0" };
-    constexpr char     SPEC_MINER_NONCE[]{ "cfae7df760" };
-
-
-    // Mirror of resolver::ResolverAmdEthash::submit(): the found nonce is printed
-    // as lower-case hex and the leading extranonce hex chars are dropped to leave
-    // the minernonce that goes into mining.submit params[2].
-    std::string toMinerNonce(uint64_t const nonce, uint32_t const extraNonceSize)
-    {
-        std::stringstream nonceHexa;
-        nonceHexa << std::hex << nonce;
-        return nonceHexa.str().substr(extraNonceSize);
-    }
+    std::stringstream nonceHexa;
+    nonceHexa << std::hex << nonce;
+    return nonceHexa.str().substr(extraNonceSize);
 }
 
 
 struct StratumEthashSubmitNonceTest : public testing::Test
 {
     StratumEthashSubmitNonceTest() = default;
-    ~StratumEthashSubmitNonceTest() override = default;
+    ~StratumEthashSubmitNonceTest() = default;
 };
 
 


### PR DESCRIPTION
## Problem

`ethash_build_dag` generates the DAG with one work-item per page and a 2D launch of `(maxGroupSize, numberItem / maxGroupSize)`. On some drivers — observed on **AMD gfx1201 / RDNA4 (RX 9070 XT)** — the runtime silently executes far fewer work-groups than requested when a launch dimension is very large. Only the first ~2^24 (16,777,216) pages get written; the rest of a multi-GB DAG stays **zero**.

Hashing over the zeroed pages produces wrong results, so **every share is rejected (`Share above target`)**. Algorithms whose DAG fits under the limit (e.g. kawpow at low epochs, ~2.1 GB) are unaffected — which is why progpow worked while mainnet ethash epochs (5.77 GB, ~45M pages) did not.

## Fix

- **`sources/algo/ethash/opencl/ethash_dag.cl`** — grid-stride over every page so coverage no longer depends on how many work-items actually run.
- **`sources/resolver/amd/ethash.cpp` & `sources/resolver/amd/progpow.cpp`** — cap the launch Y dimension (32768) so the dispatch is complete and `get_global_size()` reflects the real launch; the kernel grid-strides to cover the rest.

The search kernel is unchanged. The change is a no-op for DAGs that already fit in one launch.

The **NVIDIA CUDA** build path is **not affected**: `ethashBuildDag` (`sources/algo/ethash/cuda/dag.cuh`) already builds the DAG in a host-side loop of small `<<<512, 128>>>` launches with a `startIndex` offset, so no launch dimension approaches the grid limit. Only the AMD path issued a single oversized launch.

## Verification (RX 9070 XT, OpenCL)

- `ResolverEthashAmdTest` known-answer `findNonce` (epoch 560) — **passes** (failed before the fix).
- Live NiceHash `daggerhashimoto` ethash — **accepted shares, ~31 MH/s** (was 100% rejected).
- `ResolverKawpowAmdTest.findNonce` / `ResolverProgpowQuaiAmdTest.findNonce` — still pass.
