### PR TITLE
fix(amd): return ulong from initialize_seed for meowpow/firopow/evrprogpow

### DIFF
--- a/sources/algo/progpow/opencl/evrprogpow_functions.cl
+++ b/sources/algo/progpow/opencl/evrprogpow_functions.cl
@@ -1,5 +1,5 @@
 inline
-void initialize_seed(
+ulong initialize_seed(
     __constant uint4 const* const restrict header,
     uint* const restrict seed,
     ulong const nonce)
@@ -34,6 +34,8 @@ void initialize_seed(
     seed[24] = 'W';
 
     keccak_f800(seed);
+
+    return ((ulong)seed[1]) << 32 | seed[0];
 }
 
 

--- a/sources/algo/progpow/opencl/firopow_functions.cl
+++ b/sources/algo/progpow/opencl/firopow_functions.cl
@@ -1,5 +1,5 @@
 inline
-void initialize_seed(
+ulong initialize_seed(
     __constant uint4 const* const restrict header,
     uint* const restrict seed,
     ulong const nonce)
@@ -34,6 +34,8 @@ void initialize_seed(
     seed[24] = 0x00;
 
     keccak_f800(seed);
+
+    return ((ulong)seed[1]) << 32 | seed[0];
 }
 
 

--- a/sources/algo/progpow/opencl/meowpow_functions.cl
+++ b/sources/algo/progpow/opencl/meowpow_functions.cl
@@ -1,5 +1,5 @@
 inline
-void initialize_seed(
+ulong initialize_seed(
     __constant uint4 const* const restrict header,
     uint* const restrict seed,
     ulong const nonce)
@@ -36,6 +36,8 @@ void initialize_seed(
     seed[24] = 'W';
 
     keccak_f800(seed);
+
+    return ((ulong)seed[1]) << 32 | seed[0];
 }
 
 


### PR DESCRIPTION
## Problem

The shared `progpow.cl` kernel computes the seed with a value-returning call:

```c
ulong const seed = initialize_seed(header, state_mix, nonce);
```

`kawpow_functions.cl` and `progpow_functions.cl` return `ulong`, but
`meowpow_functions.cl`, `firopow_functions.cl` and `evrprogpow_functions.cl`
still declared the old out-parameter form `void initialize_seed(..., uint* seed)`.
The OpenCL build therefore fails with:

```
error: initializing 'const __private ulong' with an expression of incompatible type 'void'
```

so MeowPoW, FiroPoW and EvrProgPoW cannot run on AMD at all.

## Fix

Return `((ulong)seed[1]) << 32 | seed[0]` from the three variants (matching
`kawpow_functions.cl`). The per-coin keccak padding constants are untouched.

## Testing

On a Radeon RX 9070 XT (gfx1201):

- `ResolverMeowpowAmdTest.findNonce` and `ResolverFiropowAmdTest.findNonce` pass (they previously failed to build).
- MeowPoW mines live (woolypooly) with accepted shares, 0 rejects.
- EvrProgPoW shares the identical fix and now compiles (there is no AMD known-answer test to verify its hash output).