### PR TITLE
fix(algo): size autolykos isValidShare hex buffers to stop a stack overflow

### DIFF
--- a/sources/algo/autolykos/autolykos_mhssamadani.cpp
+++ b/sources/algo/autolykos/autolykos_mhssamadani.cpp
@@ -435,14 +435,17 @@ bool algo::autolykos_v2::mhssamadani::isValidShare(
     uint8_t nonce[algo::autolykos_v2::NONCE_SIZE_8]{
         0,
     };
-    char n_str[algo::autolykos_v2::NONCE_SIZE_8]{
+    // Holds the hex string of `nonce` (2 chars/byte) plus a NUL terminator; the
+    // hex helpers write inlen*2 chars + '\0'. Sizing this NONCE_SIZE_8 overflowed
+    // the stack (smashing the canary -> abort) once a candidate was verified.
+    char n_str[algo::autolykos_v2::NONCE_SIZE_8 * 2u + 1u]{
         0,
     };
 
     uint8_t height[HEIGHT_SIZE]{
         0,
     };
-    char h_str[HEIGHT_SIZE]{
+    char h_str[HEIGHT_SIZE * 2u + 1u]{
         0,
     };
 


### PR DESCRIPTION
## Problem

`algo::autolykos_v2::mhssamadani::isValidShare` declares:

```c
char n_str[NONCE_SIZE_8];   // 8
char h_str[HEIGHT_SIZE];    // 4
```

but `LittleEndianToHexStr` / `BigEndianToHexStr` write the **hex** representation —
`2 * len` characters plus a NUL terminator (`out[inlen << 1] = '\0'`). That
overruns `n_str` by 9 bytes and `h_str` by 5, corrupting the stack. The process
aborts whenever the search kernel reports a candidate (the only time
`isValidShare` runs), so AutolykosV2 crashes the moment it would submit a share.

## Fix

Size the buffers `len * 2 + 1`.

## Testing

On a Radeon RX 9070 XT (gfx1201):

- `ResolverAutolykosv2AmdTest.*` pass (they previously aborted with a stack-smash).
- The miner mines Ergo live (erg.2miners.com) with 0 rejects; before this it aborted on the first found share.

This is shared host code, so the NVIDIA resolver benefits from the fix as well.