### PR TITLE
fix(stratum): derive progpow DAG epoch from seedHash, not block height

### DIFF
--- a/sources/algo/ethash/tests/ethash.cpp
+++ b/sources/algo/ethash/tests/ethash.cpp
@@ -45,6 +45,24 @@ TEST_F(EthashTest, epoch)
 }
 
 
+// Regression for the live FiroPoW "Invalid Firo Mixhash" bug (2026-06): the DAG
+// epoch must be recovered from the network seedHash, NOT computed as
+// blockNumber/EPOCH_LENGTH. Firo changed its epoch length between early and current
+// blocks, so the constant derives the wrong epoch (e.g. block 1319805 gave 1015 via
+// /1300, but the real epoch is 650) -> wrong DAG -> every share rejected. This pins
+// a real WoolyPooly firo seedHash to its epoch (650), the value StratumProgPOW now
+// derives via findEpoch(seedHash). The seed for a given epoch is fixed forever, so
+// this assertion is stable as the chain advances.
+TEST_F(EthashTest, firoEpochFromSeedHash)
+{
+    algo::hash256 const firoSeed{
+        algo::toHash256("969685223d756d0d2c314efcb880b13fd979b38e23cfc77bbf3d66e69949566e") };
+
+    EXPECT_EQ(650,
+              algo::ethash::ContextGenerator::instance().findEpoch(firoSeed, cast32(algo::ethash::MAX_EPOCH_NUMBER)));
+}
+
+
 TEST_F(EthashTest, lightCacheBuild)
 {
     algo::DagContext context{};

--- a/sources/stratum/progpow.cpp
+++ b/sources/stratum/progpow.cpp
@@ -323,7 +323,9 @@ void stratum::StratumProgPOW::onMiningNotify(boost::json::object const& root)
             // derives the wrong epoch (wrong DAG -> "Invalid Mixhash" reject) for live
             // Firo. Prefer the seed hash (as the ethash path already does); fall back
             // to blockNumber/EPOCH_LENGTH only if the seed isn't recognized.
-            int32_t epoch{ algo::ethash::ContextGenerator::instance().findEpoch(jobInfo.seedHash, maxEthashEpoch) };
+            // maxEpochSearch caps the seed search at a max epoch *number* (not a
+            // per-epoch length), so it must stay generous as the chain's epoch climbs.
+            int32_t epoch{ algo::ethash::ContextGenerator::instance().findEpoch(jobInfo.seedHash, maxEpochSearch) };
             if (-1 == epoch && jobInfo.blockNumber > 0ull)
             {
                 epoch = cast32(jobInfo.blockNumber / castU64(maxEpochLength));
@@ -393,7 +395,7 @@ void stratum::StratumProgPOW::onMiningNotify(boost::json::object const& root)
             }
             else
             {
-                epoch = algo::ethash::ContextGenerator::instance().findEpoch(jobInfo.seedHash, maxEthashEpoch);
+                epoch = algo::ethash::ContextGenerator::instance().findEpoch(jobInfo.seedHash, maxEpochSearch);
             }
             if (-1 != epoch)
             {

--- a/sources/stratum/progpow.cpp
+++ b/sources/stratum/progpow.cpp
@@ -317,14 +317,16 @@ void stratum::StratumProgPOW::onMiningNotify(boost::json::object const& root)
             }
 
             ////////////////////////////////////////////////////////////////////
-            int32_t epoch{ 0 };
-            if (jobInfo.blockNumber > 0ull)
+            // The DAG epoch is whatever the network seedHash encodes — authoritative
+            // even when a chain changes its epoch length. Firo's FiroPoW epoch length
+            // differs between early and current blocks, so blockNumber/EPOCH_LENGTH
+            // derives the wrong epoch (wrong DAG -> "Invalid Mixhash" reject) for live
+            // Firo. Prefer the seed hash (as the ethash path already does); fall back
+            // to blockNumber/EPOCH_LENGTH only if the seed isn't recognized.
+            int32_t epoch{ algo::ethash::ContextGenerator::instance().findEpoch(jobInfo.seedHash, maxEthashEpoch) };
+            if (-1 == epoch && jobInfo.blockNumber > 0ull)
             {
                 epoch = cast32(jobInfo.blockNumber / castU64(maxEpochLength));
-            }
-            else
-            {
-                epoch = algo::ethash::ContextGenerator::instance().findEpoch(jobInfo.seedHash, maxEthashEpoch);
             }
             if (-1 != epoch)
             {

--- a/sources/stratum/progpow.hpp
+++ b/sources/stratum/progpow.hpp
@@ -23,7 +23,11 @@ namespace stratum
 
       protected:
         uint32_t maxPeriod{ algo::progpow::v_0_9_2::MAX_PERIOD };
-        uint32_t maxEthashEpoch{ algo::ethash::EPOCH_LENGTH };
+        // Upper bound for the seedHash -> epoch search (max epoch *number*, not a
+        // per-epoch block count). Generous on purpose so the search covers every
+        // realistic progpow/FiroPoW epoch; see onMiningNotify.
+        uint32_t maxEpochSearch{ algo::ethash::EPOCH_LENGTH };
+        // Blocks-per-epoch divisor for the blockNumber/length fallback.
         uint32_t maxEpochLength{ algo::progpow::EPOCH_LENGTH };
 
       private:


### PR DESCRIPTION
## Problem

FiroPoW pools (WoolyPooly, RPlant) rejected **every** share with `Invalid Firo Mixhash`.

`StratumProgPOW::onMiningNotify` computes the DAG epoch as `blockNumber / EPOCH_LENGTH`. Firo changed its FiroPoW epoch length between early and current blocks, so a fixed constant derives the wrong epoch for live blocks:

- block `1319805` → `1015` via `/1300`
- the real epoch encoded by the network `seedHash` is `650`

Wrong epoch → wrong DAG → wrong mix → 100% rejected.

## Fix

Derive the epoch from the `seedHash` via `ContextGenerator::findEpoch()` first — this is authoritative regardless of any epoch-length change, and is exactly what `StratumEthash` already does. Fall back to `blockNumber / EPOCH_LENGTH` only when the seed isn't recognized.

```cpp
int32_t epoch{ ContextGenerator::instance().findEpoch(jobInfo.seedHash, maxEthashEpoch) };
if (-1 == epoch && jobInfo.blockNumber > 0ull)
{
    epoch = cast32(jobInfo.blockNumber / castU64(maxEpochLength));
}
```

## Verification

- Live on WoolyPooly: FiroPoW now **accepted** (was 100% rejected); kawpow still accepted via the shared V1 path (no regression).
- Adds a hermetic regression test `EthashTest.firoEpochFromSeedHash` pinning a real Firo `seedHash` to epoch 650. The seed for a given epoch is fixed forever, so the assertion is stable as the chain advances.

Note: unit tests aren't built by the current CI (`BUILD_EXE_UNIT_TEST=OFF`); the test is for local runs / regression documentation.

Related but independent: the DAG-build coverage fix in #136 addresses a different large-DAG defect.