### PR TITLE
fix: portability of chrono.hpp / bitwise.hpp on non-AMD and non-MSVC builds

### DIFF
--- a/sources/algo/bitwise.hpp
+++ b/sources/algo/bitwise.hpp
@@ -2,9 +2,11 @@
 
 #if !defined(__LIB_CUDA)
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
+// Windows (MSVC and MinGW/clang): no <endian.h>. _byteswap_* live in <stdlib.h>;
+// byte-order macros are provided by the compiler or defined below.
 #include <stdlib.h>
-#elif defined(__linux__) || defined(__GNUC__)
+#elif defined(__linux__)
 #include <endian.h>
 #endif
 

--- a/sources/common/chrono.hpp
+++ b/sources/common/chrono.hpp
@@ -2,6 +2,8 @@
 
 
 #include <chrono>
+#include <cstdint>
+#include <string>
 
 
 namespace common


### PR DESCRIPTION
Two small, independent header-portability fixes.

### 1. `common/chrono.hpp` — missing `<string>` / `<cstdint>`

`std::string` and the fixed-width integer types were only available transitively via `<CL/opencl.hpp>`, which `cast.hpp` pulls in **solely** under `AMD_ENABLE`. NVIDIA / CPU builds therefore failed with:

```
no type named 'string' in namespace 'std'
```

Adds the two standard includes directly so the header is self-contained on every build configuration.

### 2. `algo/bitwise.hpp` — `<endian.h>` on non-Linux GNU compilers

The include was gated on `__GNUC__`, which pulls in `<endian.h>` for *any* GCC-compatible compiler. That header is glibc-specific — clang/MinGW on Windows defines `__GNUC__` but has no `<endian.h>`, so the include failed.

- `<stdlib.h>` path → `_WIN32` (covers MSVC **and** MinGW; MSVC also defines `_WIN32`, so its behaviour is unchanged)
- `<endian.h>` path → `__linux__`

Both are compile-only fixes (no behavioural change on the existing AMD/MSVC/Linux paths). No unit test is applicable.