### PR TITLE
fix(amd): use v0.9.2 math counts for base progpow & progpowz

### DIFF
--- a/sources/resolver/amd/progpow.hpp
+++ b/sources/resolver/amd/progpow.hpp
@@ -38,8 +38,8 @@ namespace resolver
         uint32_t               dagItemParents{ algo::ethash::DAG_ITEM_PARENTS };
         uint32_t               dagCountItemsGrowth{ algo::ethash::DAG_COUNT_ITEMS_GROWTH };
         uint32_t               dagCountItemsInit{ algo::ethash::DAG_COUNT_ITEMS_INIT };
-        uint32_t               countCache{ algo::progpow::v_0_9_3::COUNT_CACHE };
-        uint32_t               countMath{ algo::progpow::v_0_9_3::COUNT_MATH };
+        uint32_t               countCache{ algo::progpow::v_0_9_2::COUNT_CACHE };
+        uint32_t               countMath{ algo::progpow::v_0_9_2::COUNT_MATH };
 
         algo::progpow::ResultShare               resultShare{};
         resolver::amd::progpow::KernelParameters parameters{};

--- a/sources/resolver/amd/tests/progpow_z.cpp
+++ b/sources/resolver/amd/tests/progpow_z.cpp
@@ -59,7 +59,7 @@ struct ResolverProgpowZAmdTest : public testing::Test
 TEST_F(ResolverProgpowZAmdTest, findNonce)
 {
     initializeDevice(0u);
-    initializeJob(0x9f990000004cb6fa);
+    initializeJob(0x62114e8a70455eef);
 
     ASSERT_TRUE(resolver.updateMemory(jobInfo));
     ASSERT_TRUE(resolver.updateConstants(jobInfo));
@@ -71,7 +71,7 @@ TEST_F(ResolverProgpowZAmdTest, findNonce)
     std::string const nonceStr{ stratum.paramSubmit[1].as_string().c_str() };
 
     using namespace std::string_literals;
-    EXPECT_EQ("0x9f990000004cb6fa"s, nonceStr);
+    EXPECT_EQ("0x62114e8a70455eef"s, nonceStr);
 }
 
 


### PR DESCRIPTION
## Problem

The AMD base ProgPoW resolver computes the wrong hash for plain `progpow` and
`progpowz`, so it never finds a valid nonce on a real job.
`ResolverProgpowZAmdTest.findNonce` has been failing for this reason.

## Root cause

`ResolverAmdProgPOW` declares `progpowVersion = V_0_9_2` (period = block / 50) but
initializes the random-math sequence counts to the **v0.9.3** values:

```cpp
uint32_t countCache{ algo::progpow::v_0_9_3::COUNT_CACHE };  // 11
uint32_t countMath { algo::progpow::v_0_9_3::COUNT_MATH  };  // 18
```

For ProgPoW v0.9.2 these must be **12 / 20**. `countCache`/`countMath` drive
`writeMathRandomKernelOpenCL`, which generates the per-period random cache-read +
math sequence, so the wrong counts make the kernel build a different sequence and
compute a different digest than the reference. The CPU (`ResolverCpuProgPOW`) and
NVIDIA (`ResolverNvidiaProgPOW`) base resolvers already use the correct `v_0_9_2`
counts -- only the AMD one diverged.

These defaults are used only by `ALGORITHM::PROGPOW` and `ALGORITHM::PROGPOWZ`;
every other variant (kawpow / meowpow / firopow / evrprogpow / progpow-quai)
overrides `countCache`/`countMath`, so they are unaffected.

## Fix

Use `v_0_9_2::COUNT_CACHE` / `v_0_9_2::COUNT_MATH` in the AMD base resolver,
matching the CPU/NVIDIA resolvers and the declared version.

Also repoint the `ResolverProgpowZAmdTest.findNonce` start nonce off a stale
vector (`0x9f99...4cb6fa`, which duplicates progpow-quai's `...4cb6fa` suffix and
was never a real solution for this job -- present since the test was first added)
to the canonical `0x62114e8a70455eef` already used by `aroundFindNonce`,
`allDeviceFindNonce`, and the NVIDIA `findNonce` test.

## Testing

On an AMD RX 9070 XT (gfx1201, Windows, OpenCL):

- before: `ResolverProgpowZAmdTest.findNonce` and `aroundFindNonce` both fail (no nonce found).
- after: `findNonce`, `aroundFindNonce`, `notFindNonce` all pass.
- regression: `ResolverKawpowAmdTest.findNonce`, `ResolverMeowpowAmdTest.findNonce`,
  `ResolverFiropowAmdTest.findNonce`, `ResolverProgpowQuaiAmdTest.findNonce` still
  pass (they override the counts, so they are unchanged).
