### PR TITLE
fix(amd): GPU telemetry via ADL2 PMLog on modern GPUs (RDNA/Vega+)

### DIFF
--- a/sources/device/device_manager_loop_statistical.cpp
+++ b/sources/device/device_manager_loop_statistical.cpp
@@ -239,10 +239,11 @@ void device::DeviceManager::showDeviceStats(
         {
             if (true == profilerAmd.valid)
             {
-                auto const activity{ profilerAmd.getCurrentActivity(device->id) };
-                coreClock = activity.iEngineClock;
-                memoryClock = activity.iMemoryClock;
-                utilizationPercent = activity.iActivityPercent;
+                auto const telemetry{ profilerAmd.getTelemetry(device->pciBus) };
+                coreClock = telemetry.coreClock;
+                memoryClock = telemetry.memoryClock;
+                utilizationPercent = telemetry.utilization;
+                power = telemetry.power;
             }
             break;
         }

--- a/sources/profiler/amd.cpp
+++ b/sources/profiler/amd.cpp
@@ -39,6 +39,49 @@ void* profiler::Amd::loadFunction(char const* name, bool const required)
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// Resolve the ADL2 (modern, context-based) entry points. Returns true only when
+/// the full set required to drive the PMLog path is present, so the caller can
+/// commit to Backend::PMLOG without re-checking individual pointers afterwards.
+bool profiler::Amd::loadAdl2Symbols()
+{
+    adl2MainControlCreate =
+        reinterpret_cast<ADL2_MAIN_CONTROL_CREATE>(loadFunction("ADL2_Main_Control_Create", false));
+    adl2MainControlDestroy =
+        reinterpret_cast<ADL2_MAIN_CONTROL_DESTROY>(loadFunction("ADL2_Main_Control_Destroy", false));
+    adl2AdapterNumberOfAdaptersGet =
+        reinterpret_cast<ADL2_ADAPTER_NUMBEROFADAPTERS_GET>(loadFunction("ADL2_Adapter_NumberOfAdapters_Get", false));
+    adl2AdapterAdapterInfoGet =
+        reinterpret_cast<ADL2_ADAPTER_ADAPTERINFO_GET>(loadFunction("ADL2_Adapter_AdapterInfo_Get", false));
+    adl2NewQueryPMLogDataGet =
+        reinterpret_cast<ADL2_PMLOG_QUERY_GET>(loadFunction("ADL2_New_QueryPMLogData_Get", false));
+
+    return nullptr != adl2MainControlCreate && nullptr != adl2NewQueryPMLogDataGet
+           && nullptr != adl2AdapterNumberOfAdaptersGet && nullptr != adl2AdapterAdapterInfoGet;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Resolve the ADL1 (legacy, context-less) entry points for the Overdrive5
+/// fallback. Only called when ADL2 is unavailable, so these symbols are never
+/// looked up on modern drivers.
+bool profiler::Amd::loadAdl1Symbols()
+{
+    adlMainControlCreate =
+        reinterpret_cast<ADL_MAIN_CONTROL_CREATE>(loadFunction("ADL_Main_Control_Create", false));
+    adlMainControlDestroy =
+        reinterpret_cast<ADL_MAIN_CONTROL_DESTROY>(loadFunction("ADL_Main_Control_Destroy", false));
+    adlAdapterNumberOfAdaptersGet =
+        reinterpret_cast<ADL_ADAPTER_NUMBEROFADAPTERS_GET>(loadFunction("ADL_Adapter_NumberOfAdapters_Get", false));
+    adlAdapterAdapterInfoGet =
+        reinterpret_cast<ADL_ADAPTER_ADAPTERINFO_GET>(loadFunction("ADL_Adapter_AdapterInfo_Get", false));
+    adlOverdrive5CurrentActivityGet =
+        reinterpret_cast<ADL_PM_ACTIVITY_GET>(loadFunction("ADL_Overdrive5_CurrentActivity_Get", false));
+
+    return nullptr != adlMainControlCreate && nullptr != adlOverdrive5CurrentActivityGet;
+}
+
+
 bool profiler::Amd::load()
 {
 #ifdef _WIN32
@@ -58,33 +101,6 @@ bool profiler::Amd::load()
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    // ADL2 (modern) entry points. Optional: absent on very old drivers, in which
-    // case we degrade to the legacy Overdrive5 path below.
-    adl2MainControlCreate =
-        reinterpret_cast<ADL2_MAIN_CONTROL_CREATE>(loadFunction("ADL2_Main_Control_Create", false));
-    adl2MainControlDestroy =
-        reinterpret_cast<ADL2_MAIN_CONTROL_DESTROY>(loadFunction("ADL2_Main_Control_Destroy", false));
-    adl2AdapterNumberOfAdaptersGet =
-        reinterpret_cast<ADL2_ADAPTER_NUMBEROFADAPTERS_GET>(loadFunction("ADL2_Adapter_NumberOfAdapters_Get", false));
-    adl2AdapterAdapterInfoGet =
-        reinterpret_cast<ADL2_ADAPTER_ADAPTERINFO_GET>(loadFunction("ADL2_Adapter_AdapterInfo_Get", false));
-    adl2NewQueryPMLogDataGet =
-        reinterpret_cast<ADL2_PMLOG_QUERY_GET>(loadFunction("ADL2_New_QueryPMLogData_Get", false));
-
-    ////////////////////////////////////////////////////////////////////////////
-    // ADL1 (legacy) entry points, used only for the Overdrive5 fallback.
-    adlMainControlCreate =
-        reinterpret_cast<ADL_MAIN_CONTROL_CREATE>(loadFunction("ADL_Main_Control_Create", false));
-    adlMainControlDestroy =
-        reinterpret_cast<ADL_MAIN_CONTROL_DESTROY>(loadFunction("ADL_Main_Control_Destroy", false));
-    adlAdapterNumberOfAdaptersGet =
-        reinterpret_cast<ADL_ADAPTER_NUMBEROFADAPTERS_GET>(loadFunction("ADL_Adapter_NumberOfAdapters_Get", false));
-    adlAdapterAdapterInfoGet =
-        reinterpret_cast<ADL_ADAPTER_ADAPTERINFO_GET>(loadFunction("ADL_Adapter_AdapterInfo_Get", false));
-    adlOverdrive5CurrentActivityGet =
-        reinterpret_cast<ADL_PM_ACTIVITY_GET>(loadFunction("ADL_Overdrive5_CurrentActivity_Get", false));
-
-    ////////////////////////////////////////////////////////////////////////////
     // ADL's malloc callback. ADL uses it to allocate the buffers it hands back
     // (adapter info, etc), so it MUST honour the requested size — the previous
     // implementation returned a fixed 1-byte block, corrupting the heap the
@@ -95,14 +111,15 @@ bool profiler::Amd::load()
 
     ////////////////////////////////////////////////////////////////////////////
     // Preferred path: ADL2 context + PMLog sensor query. Works on RDNA/Vega and
-    // newer, which is everything the legacy Overdrive5 API cannot read.
-    if (nullptr != adl2MainControlCreate && nullptr != adl2NewQueryPMLogDataGet)
+    // newer, which is everything the legacy Overdrive5 API cannot read. The ADL1
+    // symbols below are only resolved if this path is unavailable.
+    if (true == loadAdl2Symbols())
     {
         if (ADL_OK == adl2MainControlCreate(adlMalloc, 1, &context) && nullptr != context)
         {
+            backend = Backend::PMLOG;
             if (true == buildAdapterMap())
             {
-                backend = Backend::PMLOG;
                 valid = true;
                 logInfo() << "AMD telemetry backend: ADL2 PMLog (" << busToAdapter.size() << " adapter(s))";
                 return true;
@@ -120,16 +137,17 @@ bool profiler::Amd::load()
             adl2MainControlDestroy(context);
         }
         context = nullptr;
+        backend = Backend::NONE;
     }
 
     ////////////////////////////////////////////////////////////////////////////
     // Legacy fallback: ADL1 context + Overdrive5 activity. Pre-GCN1.2 only.
-    if (nullptr != adlMainControlCreate && nullptr != adlOverdrive5CurrentActivityGet)
+    if (true == loadAdl1Symbols())
     {
         if (ADL_OK == adlMainControlCreate(adlMalloc, 1))
         {
-            buildAdapterMap(); // best-effort; Overdrive5 can still use raw indices
             backend = Backend::OVERDRIVE5;
+            buildAdapterMap(); // best-effort; Overdrive5 can still use raw indices
             valid = true;
             logInfo() << "AMD telemetry backend: Overdrive5 (legacy)";
             return true;
@@ -148,7 +166,7 @@ void profiler::Amd::unload()
     {
         adlMainControlDestroy();
     }
-    if (nullptr != context && nullptr != adl2MainControlDestroy)
+    if (Backend::PMLOG == backend && nullptr != context && nullptr != adl2MainControlDestroy)
     {
         adl2MainControlDestroy(context);
         context = nullptr;
@@ -176,19 +194,23 @@ bool profiler::Amd::buildAdapterMap()
 
     int numAdapters{ 0 };
 
-    bool const useAdl2{ nullptr != context && nullptr != adl2AdapterNumberOfAdaptersGet
-                        && nullptr != adl2AdapterAdapterInfoGet };
-
-    if (true == useAdl2)
+    // Dispatch on the backend the caller already committed to, not on raw
+    // pointers: PMLOG always means the ADL2 context-based calls, OVERDRIVE5 the
+    // ADL1 context-less ones.
+    if (Backend::PMLOG == backend)
     {
         if (ADL_OK != adl2AdapterNumberOfAdaptersGet(context, &numAdapters))
         {
             return false;
         }
     }
-    else if (nullptr != adlAdapterNumberOfAdaptersGet && nullptr != adlAdapterAdapterInfoGet)
+    else if (Backend::OVERDRIVE5 == backend)
     {
-        if (ADL_OK != adlAdapterNumberOfAdaptersGet(&numAdapters))
+        // ADL1 adapter enumeration is optional (not part of loadAdl1Symbols'
+        // required set): if absent, fail the map so getTelemetry falls back to
+        // the legacy bus-as-index behaviour rather than calling a null pointer.
+        if (nullptr == adlAdapterNumberOfAdaptersGet || nullptr == adlAdapterAdapterInfoGet
+            || ADL_OK != adlAdapterNumberOfAdaptersGet(&numAdapters))
         {
             return false;
         }
@@ -207,8 +229,8 @@ bool profiler::Amd::buildAdapterMap()
     std::vector<AdapterInfo> info(static_cast<size_t>(numAdapters), AdapterInfo{});
     int const                inputSize{ static_cast<int>(sizeof(AdapterInfo) * static_cast<size_t>(numAdapters)) };
 
-    int const result{ true == useAdl2 ? adl2AdapterAdapterInfoGet(context, info.data(), inputSize)
-                                       : adlAdapterAdapterInfoGet(info.data(), inputSize) };
+    int const result{ Backend::PMLOG == backend ? adl2AdapterAdapterInfoGet(context, info.data(), inputSize)
+                                                 : adlAdapterAdapterInfoGet(info.data(), inputSize) };
     if (ADL_OK != result)
     {
         return false;

--- a/sources/profiler/amd.cpp
+++ b/sources/profiler/amd.cpp
@@ -238,7 +238,12 @@ bool profiler::Amd::buildAdapterMap()
 
     for (AdapterInfo const& adapter : info)
     {
-        if (AMD_VENDOR_ID != adapter.iVendorID || 0 == adapter.iPresent)
+        // ADL returns iVendorID signed, and integrated AMD adapters (APUs) report
+        // it negated (-1002 instead of 1002). Match either sign, otherwise the
+        // iGPU is left out of the map and borrows the dGPU's telemetry through the
+        // single-adapter fallback in resolveAdapterIndex().
+        if ((AMD_VENDOR_ID != adapter.iVendorID && -AMD_VENDOR_ID != adapter.iVendorID)
+            || 0 == adapter.iPresent)
         {
             continue;
         }
@@ -329,7 +334,14 @@ profiler::Amd::Telemetry profiler::Amd::getTelemetryPMLog(int const adapterIndex
     ADLPMLogDataOutput data{};
     if (ADL_OK != adl2NewQueryPMLogDataGet(context, adapterIndex, &data))
     {
-        logErr() << "ADL PMLog query failed (adapter " << adapterIndex << ")";
+        // Some adapters (notably integrated GPUs / APUs) return ADL_ERR_NOT_SUPPORTED
+        // here: they expose no PMLog sensors, so telemetry stays zero. Warn once per
+        // adapter instead of every stats interval.
+        if (true == warnedAdapters.insert(adapterIndex).second)
+        {
+            logWarn() << "ADL PMLog unavailable for adapter " << adapterIndex
+                      << "; telemetry will read zero for this device";
+        }
         return telemetry;
     }
 

--- a/sources/profiler/amd.cpp
+++ b/sources/profiler/amd.cpp
@@ -106,8 +106,7 @@ bool profiler::Amd::load()
     // implementation returned a fixed 1-byte block, corrupting the heap the
     // moment ADL wrote a structure into it. A captureless lambda converts to the
     // ADL_MAIN_MALLOC_CALLBACK function pointer.
-    ADL_MAIN_MALLOC_CALLBACK const adlMalloc{ [](int const size) -> void*
-                                              { return malloc(static_cast<size_t>(size)); } };
+    ADL_MAIN_MALLOC_CALLBACK const adlMalloc{ [](int const size) -> void* { return malloc(castSize(size)); } };
 
     ////////////////////////////////////////////////////////////////////////////
     // Preferred path: ADL2 context + PMLog sensor query. Works on RDNA/Vega and
@@ -115,7 +114,8 @@ bool profiler::Amd::load()
     // symbols below are only resolved if this path is unavailable.
     if (true == loadAdl2Symbols())
     {
-        if (ADL_OK == adl2MainControlCreate(adlMalloc, 1, &context) && nullptr != context)
+        int const createStatus{ adl2MainControlCreate(adlMalloc, 1, &context) };
+        if (ADL_OK == createStatus && nullptr != context)
         {
             backend = Backend::PMLOG;
             if (true == buildAdapterMap())
@@ -197,27 +197,32 @@ bool profiler::Amd::buildAdapterMap()
     // Dispatch on the backend the caller already committed to, not on raw
     // pointers: PMLOG always means the ADL2 context-based calls, OVERDRIVE5 the
     // ADL1 context-less ones.
-    if (Backend::PMLOG == backend)
+    switch (backend)
     {
-        if (ADL_OK != adl2AdapterNumberOfAdaptersGet(context, &numAdapters))
+        case Backend::PMLOG:
+        {
+            if (ADL_OK != adl2AdapterNumberOfAdaptersGet(context, &numAdapters))
+            {
+                return false;
+            }
+            break;
+        }
+        case Backend::OVERDRIVE5:
+        {
+            // ADL1 adapter enumeration is optional (not part of loadAdl1Symbols'
+            // required set): if absent, fail the map so getTelemetry falls back to
+            // the legacy bus-as-index behaviour rather than calling a null pointer.
+            if (nullptr == adlAdapterNumberOfAdaptersGet || nullptr == adlAdapterAdapterInfoGet
+                || ADL_OK != adlAdapterNumberOfAdaptersGet(&numAdapters))
+            {
+                return false;
+            }
+            break;
+        }
+        case Backend::NONE:
         {
             return false;
         }
-    }
-    else if (Backend::OVERDRIVE5 == backend)
-    {
-        // ADL1 adapter enumeration is optional (not part of loadAdl1Symbols'
-        // required set): if absent, fail the map so getTelemetry falls back to
-        // the legacy bus-as-index behaviour rather than calling a null pointer.
-        if (nullptr == adlAdapterNumberOfAdaptersGet || nullptr == adlAdapterAdapterInfoGet
-            || ADL_OK != adlAdapterNumberOfAdaptersGet(&numAdapters))
-        {
-            return false;
-        }
-    }
-    else
-    {
-        return false;
     }
 
     if (0 >= numAdapters)
@@ -225,9 +230,8 @@ bool profiler::Amd::buildAdapterMap()
         return false;
     }
 
-    // Value-initialised so ADL sees zeroed structures.
-    std::vector<AdapterInfo> info(static_cast<size_t>(numAdapters), AdapterInfo{});
-    int const                inputSize{ static_cast<int>(sizeof(AdapterInfo) * static_cast<size_t>(numAdapters)) };
+    std::vector<AdapterInfo> info(castSize(numAdapters), AdapterInfo{});
+    int const                inputSize{ cast32(sizeof(AdapterInfo) * castSize(numAdapters)) };
 
     int const result{ Backend::PMLOG == backend ? adl2AdapterAdapterInfoGet(context, info.data(), inputSize)
                                                  : adlAdapterAdapterInfoGet(info.data(), inputSize) };
@@ -248,7 +252,7 @@ bool profiler::Amd::buildAdapterMap()
             continue;
         }
         // One physical GPU can expose several ADL indices; keep the first per bus.
-        busToAdapter.emplace(static_cast<uint32_t>(adapter.iBusNumber), adapter.iAdapterIndex);
+        busToAdapter.emplace(castU32(adapter.iBusNumber), adapter.iAdapterIndex);
     }
 
     return false == busToAdapter.empty();
@@ -268,7 +272,7 @@ bool profiler::Amd::resolveAdapterIndex(uint32_t const pciBus, int& adapterIndex
         return true;
     }
 
-    if (1 == busToAdapter.size())
+    if (1u == busToAdapter.size())
     {
         adapterIndex = busToAdapter.begin()->second;
         return true;
@@ -290,18 +294,27 @@ profiler::Amd::Telemetry profiler::Amd::getTelemetry(uint32_t const pciBus)
     int adapterIndex{ 0 };
     if (false == resolveAdapterIndex(pciBus, adapterIndex))
     {
-        // Overdrive5 has no adapter map on most paths; fall back to the bus as
-        // index to preserve historical single-GPU behaviour.
-        if (Backend::OVERDRIVE5 != backend)
+        switch (backend)
         {
-            if (true == warnedBuses.insert(pciBus).second)
+            case Backend::OVERDRIVE5:
             {
-                logWarn() << "No ADL adapter matches PCI bus " << pciBus
-                          << "; telemetry will read zero for this device";
+                // Overdrive5 has no adapter map on most paths; fall back to the
+                // bus as index to preserve historical single-GPU behaviour.
+                adapterIndex = cast32(pciBus);
+                break;
             }
-            return telemetry;
+            case Backend::PMLOG:
+            case Backend::NONE:
+            {
+                bool const firstWarning{ warnedBuses.insert(pciBus).second };
+                if (true == firstWarning)
+                {
+                    logWarn() << "No ADL adapter matches PCI bus " << pciBus
+                              << "; telemetry will read zero for this device";
+                }
+                return telemetry;
+            }
         }
-        adapterIndex = static_cast<int>(pciBus);
     }
 
     switch (backend)
@@ -337,7 +350,8 @@ profiler::Amd::Telemetry profiler::Amd::getTelemetryPMLog(int const adapterIndex
         // Some adapters (notably integrated GPUs / APUs) return ADL_ERR_NOT_SUPPORTED
         // here: they expose no PMLog sensors, so telemetry stays zero. Warn once per
         // adapter instead of every stats interval.
-        if (true == warnedAdapters.insert(adapterIndex).second)
+        bool const firstWarning{ warnedAdapters.insert(adapterIndex).second };
+        if (true == firstWarning)
         {
             logWarn() << "ADL PMLog unavailable for adapter " << adapterIndex
                       << "; telemetry will read zero for this device";
@@ -348,9 +362,9 @@ profiler::Amd::Telemetry profiler::Amd::getTelemetryPMLog(int const adapterIndex
     auto const sensor{ [&data](ADL_PMLOG_SENSORS const id) -> int
                        { return 0 != data.sensors[id].supported ? data.sensors[id].value : 0; } };
 
-    telemetry.coreClock = static_cast<uint32_t>(sensor(ADL_PMLOG_CLK_GFXCLK));
-    telemetry.memoryClock = static_cast<uint32_t>(sensor(ADL_PMLOG_CLK_MEMCLK));
-    telemetry.utilization = static_cast<uint32_t>(sensor(ADL_PMLOG_INFO_ACTIVITY_GFX));
+    telemetry.coreClock = castU32(sensor(ADL_PMLOG_CLK_GFXCLK));
+    telemetry.memoryClock = castU32(sensor(ADL_PMLOG_CLK_MEMCLK));
+    telemetry.utilization = castU32(sensor(ADL_PMLOG_INFO_ACTIVITY_GFX));
 
     // Power (W): prefer whole-board, then ASIC, then GFX-domain.
     int power{ sensor(ADL_PMLOG_BOARD_POWER) };
@@ -362,7 +376,7 @@ profiler::Amd::Telemetry profiler::Amd::getTelemetryPMLog(int const adapterIndex
     {
         power = sensor(ADL_PMLOG_GFX_POWER);
     }
-    telemetry.power = static_cast<double>(power);
+    telemetry.power = castDouble(power);
 
     return telemetry;
 }
@@ -383,9 +397,9 @@ profiler::Amd::Telemetry profiler::Amd::getTelemetryOverdrive5(int const adapter
         return telemetry;
     }
 
-    telemetry.coreClock = static_cast<uint32_t>(activity.iEngineClock) / 100u; // 10 kHz -> MHz
-    telemetry.memoryClock = static_cast<uint32_t>(activity.iMemoryClock) / 100u;
-    telemetry.utilization = static_cast<uint32_t>(activity.iActivityPercent);
+    telemetry.coreClock = castU32(activity.iEngineClock) / 100u; // 10 kHz -> MHz
+    telemetry.memoryClock = castU32(activity.iMemoryClock) / 100u;
+    telemetry.utilization = castU32(activity.iActivityPercent);
 
     return telemetry;
 }

--- a/sources/profiler/amd.cpp
+++ b/sources/profiler/amd.cpp
@@ -5,7 +5,7 @@
 #else
 #include <dlfcn.h>
 #endif
-#include <cmath>
+#include <vector>
 
 #include <common/cast.hpp>
 #include <common/custom.hpp>
@@ -13,17 +13,23 @@
 #include <profiler/amd.hpp>
 
 
-void* profiler::Amd::loadFunction(char const* name)
+////////////////////////////////////////////////////////////////////////////////
+/// AMD's PCI vendor ID. Used to skip non-AMD adapters when ADL enumerates the
+/// whole system (e.g. an Intel/NVIDIA card sharing the rig).
+static constexpr int AMD_VENDOR_ID{ 1002 };
+
+
+void* profiler::Amd::loadFunction(char const* name, bool const required)
 {
 #ifdef _WIN32
     void* ptr{ castVOIDP(GetProcAddress(libModule, name)) };
-    if (nullptr == ptr) [[unlikely]]
+    if (nullptr == ptr && true == required) [[unlikely]]
     {
         logErr() << "Cannot load function: " << name << " (" << GetLastError() << ")";
     }
 #else
     void* ptr{ castVOIDP(dlsym(libModule, name)) };
-    if (nullptr == ptr) [[unlikely]]
+    if (nullptr == ptr && true == required) [[unlikely]]
     {
         logErr() << "Cannot load function: " << name << " (" << dlerror() << ")";
     }
@@ -51,35 +57,101 @@ bool profiler::Amd::load()
         return false;
     }
 
-    adlMainControlCreate = reinterpret_cast<ADL_MAIN_CONTROL_CREATE>(loadFunction("ADL_Main_Control_Create"));
-    adlMainControlDestroy = reinterpret_cast<ADL_MAIN_CONTROL_DESTROY>(loadFunction("ADL_Main_Control_Destroy"));
+    ////////////////////////////////////////////////////////////////////////////
+    // ADL2 (modern) entry points. Optional: absent on very old drivers, in which
+    // case we degrade to the legacy Overdrive5 path below.
+    adl2MainControlCreate =
+        reinterpret_cast<ADL2_MAIN_CONTROL_CREATE>(loadFunction("ADL2_Main_Control_Create", false));
+    adl2MainControlDestroy =
+        reinterpret_cast<ADL2_MAIN_CONTROL_DESTROY>(loadFunction("ADL2_Main_Control_Destroy", false));
+    adl2AdapterNumberOfAdaptersGet =
+        reinterpret_cast<ADL2_ADAPTER_NUMBEROFADAPTERS_GET>(loadFunction("ADL2_Adapter_NumberOfAdapters_Get", false));
+    adl2AdapterAdapterInfoGet =
+        reinterpret_cast<ADL2_ADAPTER_ADAPTERINFO_GET>(loadFunction("ADL2_Adapter_AdapterInfo_Get", false));
+    adl2NewQueryPMLogDataGet =
+        reinterpret_cast<ADL2_PMLOG_QUERY_GET>(loadFunction("ADL2_New_QueryPMLogData_Get", false));
+
+    ////////////////////////////////////////////////////////////////////////////
+    // ADL1 (legacy) entry points, used only for the Overdrive5 fallback.
+    adlMainControlCreate =
+        reinterpret_cast<ADL_MAIN_CONTROL_CREATE>(loadFunction("ADL_Main_Control_Create", false));
+    adlMainControlDestroy =
+        reinterpret_cast<ADL_MAIN_CONTROL_DESTROY>(loadFunction("ADL_Main_Control_Destroy", false));
+    adlAdapterNumberOfAdaptersGet =
+        reinterpret_cast<ADL_ADAPTER_NUMBEROFADAPTERS_GET>(loadFunction("ADL_Adapter_NumberOfAdapters_Get", false));
+    adlAdapterAdapterInfoGet =
+        reinterpret_cast<ADL_ADAPTER_ADAPTERINFO_GET>(loadFunction("ADL_Adapter_AdapterInfo_Get", false));
     adlOverdrive5CurrentActivityGet =
-        reinterpret_cast<ADL_PM_ACTIVITY_GET>(loadFunction("ADL_Overdrive5_CurrentActivity_Get"));
+        reinterpret_cast<ADL_PM_ACTIVITY_GET>(loadFunction("ADL_Overdrive5_CurrentActivity_Get", false));
 
-    IS_NULL(adlMainControlCreate);
-    IS_NULL(adlMainControlDestroy);
-    IS_NULL(adlOverdrive5CurrentActivityGet);
+    ////////////////////////////////////////////////////////////////////////////
+    // ADL's malloc callback. ADL uses it to allocate the buffers it hands back
+    // (adapter info, etc), so it MUST honour the requested size — the previous
+    // implementation returned a fixed 1-byte block, corrupting the heap the
+    // moment ADL wrote a structure into it. A captureless lambda converts to the
+    // ADL_MAIN_MALLOC_CALLBACK function pointer.
+    ADL_MAIN_MALLOC_CALLBACK const adlMalloc{ [](int const size) -> void*
+                                              { return malloc(static_cast<size_t>(size)); } };
 
-    auto cbAdlControlCreate{ [](int) -> void*
-                             {
-                                 return malloc(1);
-                             } };
-    if (ADL_OK != adlMainControlCreate(cbAdlControlCreate, 1))
+    ////////////////////////////////////////////////////////////////////////////
+    // Preferred path: ADL2 context + PMLog sensor query. Works on RDNA/Vega and
+    // newer, which is everything the legacy Overdrive5 API cannot read.
+    if (nullptr != adl2MainControlCreate && nullptr != adl2NewQueryPMLogDataGet)
     {
-        return false;
+        if (ADL_OK == adl2MainControlCreate(adlMalloc, 1, &context) && nullptr != context)
+        {
+            if (true == buildAdapterMap())
+            {
+                backend = Backend::PMLOG;
+                valid = true;
+                logInfo() << "AMD telemetry backend: ADL2 PMLog (" << busToAdapter.size() << " adapter(s))";
+                return true;
+            }
+            logErr() << "ADL2 found no AMD adapters; falling back to Overdrive5";
+        }
+        else
+        {
+            logErr() << "ADL2_Main_Control_Create failed; falling back to Overdrive5";
+        }
+
+        // ADL2 context unusable — tear it down before trying the legacy path.
+        if (nullptr != context && nullptr != adl2MainControlDestroy)
+        {
+            adl2MainControlDestroy(context);
+        }
+        context = nullptr;
     }
 
-    valid = true;
+    ////////////////////////////////////////////////////////////////////////////
+    // Legacy fallback: ADL1 context + Overdrive5 activity. Pre-GCN1.2 only.
+    if (nullptr != adlMainControlCreate && nullptr != adlOverdrive5CurrentActivityGet)
+    {
+        if (ADL_OK == adlMainControlCreate(adlMalloc, 1))
+        {
+            buildAdapterMap(); // best-effort; Overdrive5 can still use raw indices
+            backend = Backend::OVERDRIVE5;
+            valid = true;
+            logInfo() << "AMD telemetry backend: Overdrive5 (legacy)";
+            return true;
+        }
+        logErr() << "ADL_Main_Control_Create failed";
+    }
 
-    return true;
+    logErr() << "No usable AMD telemetry backend (ADL2 PMLog / Overdrive5 unavailable)";
+    return false;
 }
 
 
 void profiler::Amd::unload()
 {
-    if (nullptr != adlMainControlDestroy)
+    if (Backend::OVERDRIVE5 == backend && nullptr != adlMainControlDestroy)
     {
         adlMainControlDestroy();
+    }
+    if (nullptr != context && nullptr != adl2MainControlDestroy)
+    {
+        adl2MainControlDestroy(context);
+        context = nullptr;
     }
     if (nullptr != libModule)
     {
@@ -88,21 +160,200 @@ void profiler::Amd::unload()
 #else
         dlclose(libModule);
 #endif
+        libModule = nullptr;
     }
 }
 
 
-ADLPMActivity profiler::Amd::getCurrentActivity(uint32_t const id)
+////////////////////////////////////////////////////////////////////////////////
+/// Enumerate ADL adapters and map each AMD GPU's PCI bus number to its ADL
+/// adapter index. The ADL adapter index is neither the OpenCL device index nor
+/// the PCI bus, so the only reliable cross-reference is the bus number, which the
+/// device layer already tracks.
+bool profiler::Amd::buildAdapterMap()
 {
+    busToAdapter.clear();
+
+    int numAdapters{ 0 };
+
+    bool const useAdl2{ nullptr != context && nullptr != adl2AdapterNumberOfAdaptersGet
+                        && nullptr != adl2AdapterAdapterInfoGet };
+
+    if (true == useAdl2)
+    {
+        if (ADL_OK != adl2AdapterNumberOfAdaptersGet(context, &numAdapters))
+        {
+            return false;
+        }
+    }
+    else if (nullptr != adlAdapterNumberOfAdaptersGet && nullptr != adlAdapterAdapterInfoGet)
+    {
+        if (ADL_OK != adlAdapterNumberOfAdaptersGet(&numAdapters))
+        {
+            return false;
+        }
+    }
+    else
+    {
+        return false;
+    }
+
+    if (0 >= numAdapters)
+    {
+        return false;
+    }
+
+    // Value-initialised so ADL sees zeroed structures.
+    std::vector<AdapterInfo> info(static_cast<size_t>(numAdapters), AdapterInfo{});
+    int const                inputSize{ static_cast<int>(sizeof(AdapterInfo) * static_cast<size_t>(numAdapters)) };
+
+    int const result{ true == useAdl2 ? adl2AdapterAdapterInfoGet(context, info.data(), inputSize)
+                                       : adlAdapterAdapterInfoGet(info.data(), inputSize) };
+    if (ADL_OK != result)
+    {
+        return false;
+    }
+
+    for (AdapterInfo const& adapter : info)
+    {
+        if (AMD_VENDOR_ID != adapter.iVendorID || 0 == adapter.iPresent)
+        {
+            continue;
+        }
+        // One physical GPU can expose several ADL indices; keep the first per bus.
+        busToAdapter.emplace(static_cast<uint32_t>(adapter.iBusNumber), adapter.iAdapterIndex);
+    }
+
+    return false == busToAdapter.empty();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Translate a device PCI bus number into an ADL adapter index. If the map only
+/// holds a single AMD GPU, accept it regardless of bus so a mismatch in bus
+/// numbering still yields telemetry on single-card rigs.
+bool profiler::Amd::resolveAdapterIndex(uint32_t const pciBus, int& adapterIndex)
+{
+    auto const it{ busToAdapter.find(pciBus) };
+    if (it != busToAdapter.end())
+    {
+        adapterIndex = it->second;
+        return true;
+    }
+
+    if (1 == busToAdapter.size())
+    {
+        adapterIndex = busToAdapter.begin()->second;
+        return true;
+    }
+
+    return false;
+}
+
+
+profiler::Amd::Telemetry profiler::Amd::getTelemetry(uint32_t const pciBus)
+{
+    Telemetry telemetry{};
+
+    if (false == valid)
+    {
+        return telemetry;
+    }
+
+    int adapterIndex{ 0 };
+    if (false == resolveAdapterIndex(pciBus, adapterIndex))
+    {
+        // Overdrive5 has no adapter map on most paths; fall back to the bus as
+        // index to preserve historical single-GPU behaviour.
+        if (Backend::OVERDRIVE5 != backend)
+        {
+            if (true == warnedBuses.insert(pciBus).second)
+            {
+                logWarn() << "No ADL adapter matches PCI bus " << pciBus
+                          << "; telemetry will read zero for this device";
+            }
+            return telemetry;
+        }
+        adapterIndex = static_cast<int>(pciBus);
+    }
+
+    switch (backend)
+    {
+        case Backend::PMLOG:
+        {
+            return getTelemetryPMLog(adapterIndex);
+        }
+        case Backend::OVERDRIVE5:
+        {
+            return getTelemetryOverdrive5(adapterIndex);
+        }
+        case Backend::NONE:
+        {
+            break;
+        }
+    }
+
+    return telemetry;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Read live sensors via ADL2 PMLog. Each sensor is indexed by its
+/// ADL_PMLOG_SENSORS enum value and carries a `supported` flag.
+profiler::Amd::Telemetry profiler::Amd::getTelemetryPMLog(int const adapterIndex)
+{
+    Telemetry telemetry{};
+
+    ADLPMLogDataOutput data{};
+    if (ADL_OK != adl2NewQueryPMLogDataGet(context, adapterIndex, &data))
+    {
+        logErr() << "ADL PMLog query failed (adapter " << adapterIndex << ")";
+        return telemetry;
+    }
+
+    auto const sensor{ [&data](ADL_PMLOG_SENSORS const id) -> int
+                       { return 0 != data.sensors[id].supported ? data.sensors[id].value : 0; } };
+
+    telemetry.coreClock = static_cast<uint32_t>(sensor(ADL_PMLOG_CLK_GFXCLK));
+    telemetry.memoryClock = static_cast<uint32_t>(sensor(ADL_PMLOG_CLK_MEMCLK));
+    telemetry.utilization = static_cast<uint32_t>(sensor(ADL_PMLOG_INFO_ACTIVITY_GFX));
+
+    // Power (W): prefer whole-board, then ASIC, then GFX-domain.
+    int power{ sensor(ADL_PMLOG_BOARD_POWER) };
+    if (0 == power)
+    {
+        power = sensor(ADL_PMLOG_ASIC_POWER);
+    }
+    if (0 == power)
+    {
+        power = sensor(ADL_PMLOG_GFX_POWER);
+    }
+    telemetry.power = static_cast<double>(power);
+
+    return telemetry;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Legacy Overdrive5 activity read. Clocks are reported in units of 10 kHz.
+profiler::Amd::Telemetry profiler::Amd::getTelemetryOverdrive5(int const adapterIndex)
+{
+    Telemetry telemetry{};
+
     ADLPMActivity activity{};
     activity.iSize = sizeof(ADLPMActivity);
 
-    if (ADL_OK != adlOverdrive5CurrentActivityGet(id, &activity))
+    if (ADL_OK != adlOverdrive5CurrentActivityGet(adapterIndex, &activity))
     {
-        logErr() << "ADL cannot get activity";
+        logErr() << "ADL cannot get activity (adapter " << adapterIndex << ")";
+        return telemetry;
     }
 
-    return activity;
+    telemetry.coreClock = static_cast<uint32_t>(activity.iEngineClock) / 100u; // 10 kHz -> MHz
+    telemetry.memoryClock = static_cast<uint32_t>(activity.iMemoryClock) / 100u;
+    telemetry.utilization = static_cast<uint32_t>(activity.iActivityPercent);
+
+    return telemetry;
 }
 
 #endif

--- a/sources/profiler/amd.hpp
+++ b/sources/profiler/amd.hpp
@@ -2,6 +2,10 @@
 
 #if defined(AMD_ENABLE)
 
+#include <cstdint>
+#include <map>
+#include <set>
+
 #include <profiler/adl/adl_sdk.h>
 
 
@@ -10,29 +14,82 @@ namespace profiler
     struct Amd
     {
       public:
+        ////////////////////////////////////////////////////////////////////////
+        /// Backend-agnostic telemetry snapshot for a single GPU.
+        struct Telemetry
+        {
+            uint32_t coreClock{ 0u };   //!< Engine/GFX clock (MHz)
+            uint32_t memoryClock{ 0u }; //!< Memory clock (MHz)
+            uint32_t utilization{ 0u }; //!< GPU activity (%)
+            double   power{ 0.0 };      //!< Board/ASIC power draw (W)
+        };
+
         bool valid{ false };
 
-        bool          load();
-        void          unload();
-        ADLPMActivity getCurrentActivity(uint32_t const id);
+        bool      load();
+        void      unload();
+        Telemetry getTelemetry(uint32_t const pciBus);
 
       private:
+        ////////////////////////////////////////////////////////////////////////
+        /// Which AMD telemetry API the loaded driver actually supports.
+        /// PMLOG is the modern path (RDNA/Vega+); OVERDRIVE5 is the legacy
+        /// fallback for pre-GCN1.2 cards. A future ADLX backend slots in here.
+        enum class Backend
+        {
+            NONE,
+            PMLOG,
+            OVERDRIVE5
+        };
+
 #if defined(_WIN32)
         HMODULE libModule{ nullptr };
 #else
         void* libModule{ nullptr };
 #endif
 
-        using ADL_MAIN_CONTROL_CREATE = int (*)(ADL_MAIN_MALLOC_CALLBACK callback, int enumConnectedAdapters);
-        using ADL_MAIN_CONTROL_DESTROY = int (*)();
-        using ADL_PM_ACTIVITY_GET = int (*)(int iAdapterIndex, ADLPMActivity* lpActivity);
+        ADL_CONTEXT_HANDLE      context{ nullptr };
+        Backend                 backend{ Backend::NONE };
+        std::map<uint32_t, int> busToAdapter{};  //!< PCI bus number -> ADL adapter index
+        std::set<uint32_t>      warnedBuses{};    //!< Buses already warned about (avoid per-interval spam)
 
-        ADL_MAIN_CONTROL_CREATE  adlMainControlCreate{ nullptr };
-        ADL_MAIN_CONTROL_DESTROY adlMainControlDestroy{ nullptr };
-        ADL_PM_ACTIVITY_GET      adlOverdrive5CurrentActivityGet{ nullptr };
+        ////////////////////////////////////////////////////////////////////////
+        // ADL1 (legacy, context-less)
+        using ADL_MAIN_CONTROL_CREATE        = int (*)(ADL_MAIN_MALLOC_CALLBACK callback, int enumConnectedAdapters);
+        using ADL_MAIN_CONTROL_DESTROY       = int (*)();
+        using ADL_ADAPTER_NUMBEROFADAPTERS_GET = int (*)(int* lpNumAdapters);
+        using ADL_ADAPTER_ADAPTERINFO_GET    = int (*)(LPAdapterInfo lpInfo, int iInputSize);
+        using ADL_PM_ACTIVITY_GET            = int (*)(int iAdapterIndex, ADLPMActivity* lpActivity);
 
-        void* loadFunction(char const* name);
+        ////////////////////////////////////////////////////////////////////////
+        // ADL2 (modern, context-based)
+        using ADL2_MAIN_CONTROL_CREATE =
+            int (*)(ADL_MAIN_MALLOC_CALLBACK callback, int enumConnectedAdapters, ADL_CONTEXT_HANDLE* context);
+        using ADL2_MAIN_CONTROL_DESTROY         = int (*)(ADL_CONTEXT_HANDLE context);
+        using ADL2_ADAPTER_NUMBEROFADAPTERS_GET = int (*)(ADL_CONTEXT_HANDLE context, int* lpNumAdapters);
+        using ADL2_ADAPTER_ADAPTERINFO_GET = int (*)(ADL_CONTEXT_HANDLE context, LPAdapterInfo lpInfo, int iInputSize);
+        using ADL2_PMLOG_QUERY_GET =
+            int (*)(ADL_CONTEXT_HANDLE context, int iAdapterIndex, ADLPMLogDataOutput* lpDataOutput);
+
+        ADL_MAIN_CONTROL_CREATE          adlMainControlCreate{ nullptr };
+        ADL_MAIN_CONTROL_DESTROY         adlMainControlDestroy{ nullptr };
+        ADL_ADAPTER_NUMBEROFADAPTERS_GET adlAdapterNumberOfAdaptersGet{ nullptr };
+        ADL_ADAPTER_ADAPTERINFO_GET      adlAdapterAdapterInfoGet{ nullptr };
+        ADL_PM_ACTIVITY_GET              adlOverdrive5CurrentActivityGet{ nullptr };
+
+        ADL2_MAIN_CONTROL_CREATE          adl2MainControlCreate{ nullptr };
+        ADL2_MAIN_CONTROL_DESTROY         adl2MainControlDestroy{ nullptr };
+        ADL2_ADAPTER_NUMBEROFADAPTERS_GET adl2AdapterNumberOfAdaptersGet{ nullptr };
+        ADL2_ADAPTER_ADAPTERINFO_GET      adl2AdapterAdapterInfoGet{ nullptr };
+        ADL2_PMLOG_QUERY_GET              adl2NewQueryPMLogDataGet{ nullptr };
+
+        void* loadFunction(char const* name, bool const required = true);
+        bool  buildAdapterMap();
+        bool  resolveAdapterIndex(uint32_t const pciBus, int& adapterIndex);
+
+        Telemetry getTelemetryPMLog(int const adapterIndex);
+        Telemetry getTelemetryOverdrive5(int const adapterIndex);
     };
 }
 
-#endif //! CUDA_ENABLE
+#endif //! AMD_ENABLE

--- a/sources/profiler/amd.hpp
+++ b/sources/profiler/amd.hpp
@@ -18,10 +18,10 @@ namespace profiler
         /// Backend-agnostic telemetry snapshot for a single GPU.
         struct Telemetry
         {
-            uint32_t coreClock{ 0u };   //!< Engine/GFX clock (MHz)
-            uint32_t memoryClock{ 0u }; //!< Memory clock (MHz)
-            uint32_t utilization{ 0u }; //!< GPU activity (%)
-            double   power{ 0.0 };      //!< Board/ASIC power draw (W)
+            uint32_t coreClock{ 0u };   // Engine/GFX clock (MHz)
+            uint32_t memoryClock{ 0u }; // Memory clock (MHz)
+            uint32_t utilization{ 0u }; // GPU activity (%)
+            double   power{ 0.0 };      // Board/ASIC power draw (W)
         };
 
         bool valid{ false };
@@ -38,11 +38,11 @@ namespace profiler
         /// for pre-GCN1.2 cards. Once `load()` picks a backend, every call site
         /// dispatches on this enum instead of re-checking raw function pointers.
         /// A future ADLX backend slots in here.
-        enum class Backend
+        enum class Backend : uint8_t
         {
             NONE,
-            PMLOG,     //!< ADL2 context + PMLog sensor query
-            OVERDRIVE5 //!< ADL1 context-less Overdrive5 activity
+            PMLOG,     // ADL2 context + PMLog sensor query
+            OVERDRIVE5 // ADL1 context-less Overdrive5 activity
         };
 
 #if defined(_WIN32)
@@ -53,9 +53,9 @@ namespace profiler
 
         ADL_CONTEXT_HANDLE      context{ nullptr };
         Backend                 backend{ Backend::NONE };
-        std::map<uint32_t, int> busToAdapter{};   //!< PCI bus number -> ADL adapter index
-        std::set<uint32_t>      warnedBuses{};     //!< Buses already warned about (avoid per-interval spam)
-        std::set<int>           warnedAdapters{};  //!< Adapters whose PMLog query failed (warn once)
+        std::map<uint32_t, int> busToAdapter{};   // PCI bus number -> ADL adapter index
+        std::set<uint32_t>      warnedBuses{};     // Buses already warned about (avoid per-interval spam)
+        std::set<int>           warnedAdapters{};  // Adapters whose PMLog query failed (warn once)
 
         ////////////////////////////////////////////////////////////////////////
         // ADL1 (legacy, context-less)

--- a/sources/profiler/amd.hpp
+++ b/sources/profiler/amd.hpp
@@ -53,8 +53,9 @@ namespace profiler
 
         ADL_CONTEXT_HANDLE      context{ nullptr };
         Backend                 backend{ Backend::NONE };
-        std::map<uint32_t, int> busToAdapter{};  //!< PCI bus number -> ADL adapter index
-        std::set<uint32_t>      warnedBuses{};    //!< Buses already warned about (avoid per-interval spam)
+        std::map<uint32_t, int> busToAdapter{};   //!< PCI bus number -> ADL adapter index
+        std::set<uint32_t>      warnedBuses{};     //!< Buses already warned about (avoid per-interval spam)
+        std::set<int>           warnedAdapters{};  //!< Adapters whose PMLog query failed (warn once)
 
         ////////////////////////////////////////////////////////////////////////
         // ADL1 (legacy, context-less)

--- a/sources/profiler/amd.hpp
+++ b/sources/profiler/amd.hpp
@@ -32,14 +32,17 @@ namespace profiler
 
       private:
         ////////////////////////////////////////////////////////////////////////
-        /// Which AMD telemetry API the loaded driver actually supports.
-        /// PMLOG is the modern path (RDNA/Vega+); OVERDRIVE5 is the legacy
-        /// fallback for pre-GCN1.2 cards. A future ADLX backend slots in here.
+        /// Which AMD telemetry API the loaded driver actually supports. This is
+        /// the single source of truth for the selected ADL version: PMLOG is the
+        /// modern ADL2 path (RDNA/Vega+); OVERDRIVE5 is the legacy ADL1 fallback
+        /// for pre-GCN1.2 cards. Once `load()` picks a backend, every call site
+        /// dispatches on this enum instead of re-checking raw function pointers.
+        /// A future ADLX backend slots in here.
         enum class Backend
         {
             NONE,
-            PMLOG,
-            OVERDRIVE5
+            PMLOG,     //!< ADL2 context + PMLog sensor query
+            OVERDRIVE5 //!< ADL1 context-less Overdrive5 activity
         };
 
 #if defined(_WIN32)
@@ -84,6 +87,8 @@ namespace profiler
         ADL2_PMLOG_QUERY_GET              adl2NewQueryPMLogDataGet{ nullptr };
 
         void* loadFunction(char const* name, bool const required = true);
+        bool  loadAdl2Symbols();
+        bool  loadAdl1Symbols();
         bool  buildAdapterMap();
         bool  resolveAdapterIndex(uint32_t const pciBus, int& adapterIndex);
 


### PR DESCRIPTION
## Problem

The AMD profiler reads GPU telemetry through `ADL_Overdrive5_CurrentActivity_Get` — the legacy Overdrive 5 API, which is unsupported on every AMD GPU since GCN 1.2 (Vega, all of RDNA 1–4). On those cards the call fails, the log fills with `[getCurrentActivity] ADL cannot get activity`, and the dashboard's clock / memory-clock / utilization read 0 (power was never read on the AMD path at all).

## Change

Reworks `profiler::Amd` into a backend-aware telemetry reader:

- **Primary — ADL2 PMLog:** an ADL2 context + `ADL2_New_QueryPMLogData_Get`, reading `ADL_PMLOG_*` sensors. Works on RDNA/Vega and newer. Reports core/memory clock (MHz), GPU utilization (%) and board power (W).
- **Fallback — Overdrive 5:** retained for pre-GCN 1.2 cards.
- **PCI-bus → ADL adapter-index map:** the ADL adapter index is neither the OpenCL device id nor the PCI bus, so adapters are enumerated and matched by bus number (which the device layer already tracks) — correct telemetry on multi-GPU rigs.
- **Heap-corruption fix:** the ADL malloc callback returned a fixed 1-byte block regardless of the requested size; it now honours the size.

The device stats loop consumes a small `Telemetry` struct and now surfaces AMD power, populating the previously-dead **Power / H/W / $/H** columns. This is the ADL-native path; an ADLX backend can later slot in behind the same `getTelemetry()` interface.

## Compatibility

Requires a PMLog-capable Adrenalin driver (standard on RDNA/Vega). Cards/drivers without PMLog fall back to Overdrive 5; if neither is available the profiler degrades gracefully to zeros (no crash, single warning).

## Testing

- Built for Windows (llvm-mingw cross) and Linux (clang-15) via the project's vcpkg toolchain; both link cleanly.
- Existing unit tests pass (non-GPU suites: 30/30).
- Live-verified on an **RX 9070 XT (RDNA4 / gfx1201)**: clock / utilization / power now display correctly and the ADL activity errors are gone.