### PR TITLE
fix(api): don't crash the miner when the API port can't be bound

### DIFF
--- a/sources/api/api.cpp
+++ b/sources/api/api.cpp
@@ -35,24 +35,55 @@ void api::ServerAPI::loopAccept()
     namespace boost_http = boost::beast::http;
 
     boost_io_context ioContext{};
-    boost_acceptor   acceptor{ ioContext, { boost_tcp::v4(), castU16(port) } };
+    boost_acceptor   acceptor{ ioContext };
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Bind the acceptor defensively: the stats API is non-essential, so a bind
+    // failure (port already in use, or reserved by the OS) must not terminate
+    // the miner. Log and disable the API instead.
+    try
+    {
+        boost_endpoint const endpoint{ boost_tcp::v4(), castU16(port) };
+        acceptor.open(endpoint.protocol());
+        acceptor.set_option(boost::asio::socket_base::reuse_address{ true });
+        acceptor.bind(endpoint);
+        acceptor.listen();
+    }
+    catch (boost::system::system_error const& exception)
+    {
+        logErr() << "Cannot start API on port " << port << ": " << exception.what()
+                 << ". API disabled, mining continues. On Windows the port may sit "
+                    "in a reserved range (check `netsh int ipv4 show excludedportrange tcp`); "
+                    "pick another port with --api_port.";
+        alive.store(false, boost::memory_order::seq_cst);
+        return;
+    }
 
     while (true == alive.load(boost::memory_order::relaxed))
     {
         ////////////////////////////////////////////////////////////////////////
-        boost_socket socket{ ioContext };
-        acceptor.accept(socket);
+        // A malformed or aborted client request must not bring down the miner
+        // either, so handle each connection inside its own guard.
+        try
+        {
+            boost_socket socket{ ioContext };
+            acceptor.accept(socket);
 
-        ////////////////////////////////////////////////////////////////////////
-        boost::beast::flat_buffer                    buffer{};
-        boost_http::request<boost_http::string_body> request{};
-        boost_http::read(socket, buffer, request);
+            ////////////////////////////////////////////////////////////////////
+            boost::beast::flat_buffer                    buffer{};
+            boost_http::request<boost_http::string_body> request{};
+            boost_http::read(socket, buffer, request);
 
-        ////////////////////////////////////////////////////////////////////////
-        onMessage(socket, request);
+            ////////////////////////////////////////////////////////////////////
+            onMessage(socket, request);
 
-        ////////////////////////////////////////////////////////////////////////
-        socket.shutdown(boost_tcp::socket::shutdown_send);
+            ////////////////////////////////////////////////////////////////////
+            socket.shutdown(boost_tcp::socket::shutdown_send);
+        }
+        catch (boost::system::system_error const& exception)
+        {
+            logWarn() << "API request handling error: " << exception.what();
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

The miner terminates on startup if the stats API can't bind its port:

```
(i) - Start API on port 8080
libc++abi: terminating due to uncaught exception of type
boost::wrapexcept<boost::system::system_error>: bind: An attempt was made to
access a socket in a way forbidden by its access permissions [system:10013 ...]
```

`ServerAPI::loopAccept()` constructs the acceptor directly, with no exception handling:

```cpp
boost_acceptor acceptor{ ioContext, { boost_tcp::v4(), castU16(port) } };
```

A failed `bind()` throws `boost::system::system_error` out of the accept thread, which calls `std::terminate()` and brings down the **whole miner** — mining included. The stats API is non-essential and should never be able to do that.

## Scope

This PR addresses the **crash only** — making a non-essential service fail safe. It is not about any particular port value or environment; the same uncaught-exception path also triggers on a plain "address already in use" when another process holds the port.

## Fix

- `open`/`bind`/`listen` the acceptor inside a `try` block. On failure, log an error and **disable the API while mining continues**, instead of terminating.
- Wrap per-connection handling in its own guard so a malformed/aborted client request can't bring the miner down either.
- Set `reuse_address` on the acceptor.

## Verification

`sources/api/api.cpp` syntax-checked clean with `clang++ -std=c++20 -fsyntax-only` in a build-deps container. No interface change to `api.hpp`.
