### PR TITLE
build(windows-cross): stop overriding the pinned vcpkg ref by default

### DIFF
--- a/scripts/docker-build.ps1
+++ b/scripts/docker-build.ps1
@@ -16,7 +16,10 @@
     amd | nvidia | both   (default: both)
 
 .PARAMETER VcpkgRef
-    git ref of vcpkg to pin inside the image (default: master).
+    git ref of vcpkg to pin inside the image. Default: empty, which leaves the
+    Dockerfile's pinned VCPKG_REF (kept in lockstep with vcpkg.json's
+    builtin-baseline) in force. Override only to test a different vcpkg revision --
+    a stale override desyncs vcpkg from the baseline and breaks `vcpkg install`.
 
 .EXAMPLE
     scripts/docker-build.ps1 -Os windows-cross -Gpu both
@@ -32,7 +35,7 @@ param(
     [ValidateSet('amd', 'nvidia', 'both')]
     [string] $Gpu = 'both',
 
-    [string] $VcpkgRef = 'master'
+    [string] $VcpkgRef = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -54,13 +57,25 @@ function Build-One([string] $osName, [string] $gpu) {
     New-Item -ItemType Directory -Force -Path $out | Out-Null
     Write-Host "==> Building $name (Linux container) -> $out" -ForegroundColor Cyan
     $env:DOCKER_BUILDKIT = '1'
-    & docker build `
-        -f (Join-Path $repoRoot "docker/Dockerfile.$osName") `
-        --build-arg "GPU=$gpu" `
-        --build-arg "VCPKG_REF=$VcpkgRef" `
-        --target artifact `
-        -o $out `
-        $repoRoot
+    $dockerArgs = @(
+        'build'
+        '-f'
+        (Join-Path $repoRoot "docker/Dockerfile.$osName")
+        '--build-arg'
+        "GPU=$gpu"
+        '--target'
+        'artifact'
+        '-o'
+        $out
+    )
+    # Only override the Dockerfile's pinned VCPKG_REF when the caller explicitly asks;
+    # otherwise the image's ARG (in lockstep with vcpkg.json's builtin-baseline) wins.
+    if (-not [string]::IsNullOrWhiteSpace($VcpkgRef)) {
+        $dockerArgs += '--build-arg'
+        $dockerArgs += "VCPKG_REF=$VcpkgRef"
+    }
+    $dockerArgs += $repoRoot
+    & docker @dockerArgs
     if ($LASTEXITCODE -ne 0) { throw "docker build failed for $name" }
     Write-Host "==> $name binaries in $out" -ForegroundColor Green
 }


### PR DESCRIPTION
## Problem

`scripts/docker-build.ps1` defaults `-VcpkgRef` to `master` and passes it as `--build-arg VCPKG_REF=...` unconditionally, which **overrides** the Dockerfile's deliberate pin (`ARG VCPKG_REF=40dd49b…`, kept in lockstep with `vcpkg.json`'s `builtin-baseline`).

So a clean `docker-build.ps1 -Os windows-cross` checks out vcpkg at today's `master` while the baseline stays at `40dd49b`. Once `master` drifts from the baseline (it has), `vcpkg install` fails:

```
fatal: path 'versions/baseline.json' exists on disk, but not in '40dd49b…'
while loading baseline version for boost-thread
-- Running vcpkg install - failed
```

This breaks every clean windows-cross build, independent of the source being compiled.

## Fix

- Default `-VcpkgRef` to empty, so the Dockerfile `ARG` (single source of truth, in lockstep with `builtin-baseline`) wins.
- Pass `--build-arg VCPKG_REF=…` only when the caller explicitly sets it (override preserved for testing a different vcpkg revision).
- Switch the `docker build` invocation to a splatted args array so the override can be appended conditionally.

## Validation

- AST syntax check: clean.
- Clean `docker-build.ps1 -Os windows-cross -Gpu amd` (no `-VcpkgRef`) now runs `-- Running vcpkg install - done` with no baseline error and produces `miner.exe`.