### PR TITLE
fix(network): verify TLS with the Windows chain engine on Windows

### DIFF
--- a/sources/network/network.cpp
+++ b/sources/network/network.cpp
@@ -1,8 +1,3 @@
-#if defined(_WIN32)
-#pragma comment(lib, "crypt32.lib")
-#endif
-
-
 #include <boost/asio/buffer.hpp>
 #include <boost/bind/bind.hpp>
 #include <boost/chrono.hpp>
@@ -14,10 +9,6 @@
 #include <network/network.hpp>
 #include <network/socks5.hpp>
 #include <stratum/stratum_type.hpp>
-
-#if defined(_WIN32)
-#include <wincrypt.h>
-#endif
 
 
 network::NetworkTCPClient::~NetworkTCPClient()
@@ -230,31 +221,13 @@ bool network::NetworkTCPClient::doSecureConnection()
             boost::bind(&NetworkTCPClient::onVerifySSL, this, std::placeholders::_1, std::placeholders::_2));
 
 #if defined(_WIN32)
-        auto certStore{ CertOpenSystemStore(0, "ROOT") };
-        if (certStore == nullptr)
-        {
-            logErr() << "Certifcat Store \"ROOT\" was not found !";
-            return false;
-        }
-
-        auto*          store{ X509_STORE_new() };
-        PCCERT_CONTEXT certContext{ nullptr };
-        while (nullptr != (certContext = CertEnumCertificatesInStore(certStore, certContext)))
-        {
-            auto* x509{ d2i_X509(
-                nullptr,
-                const_cast<unsigned char const**>(&(certContext->pbCertEncoded)),
-                certContext->cbCertEncoded) };
-            if (nullptr != x509)
-            {
-                X509_STORE_add_cert(store, x509);
-                X509_free(x509);
-            }
-        }
-
-        CertFreeCertificateContext(certContext);
-        CertCloseStore(certStore, 0);
-        SSL_CTX_set_cert_store(context.native_handle(), store);
+        // No static trust store is seeded on Windows. OpenSSL cannot complete a chain whose
+        // intermediate the server omits (it has no AIA fetching), a very common pool
+        // misconfiguration. Instead onVerifySSL() hands the peer chain to the Windows chain
+        // engine (CertGetCertificateChain), which supplies the system roots, AIA-fetches any
+        // missing intermediate, and validates the hostname. verify_peer (set above) is still
+        // required so the callback runs; the empty OpenSSL store just makes `preverified`
+        // always false, which onVerifySSL expects on Windows.
 #elif defined(__linux__)
         // Fall back to OpenSSL's built-in default trust paths if the explicit
         // bundle below is absent, so verification still succeeds (fail-closed).

--- a/sources/network/network_callback.cpp
+++ b/sources/network/network_callback.cpp
@@ -3,6 +3,131 @@
 #include <common/log/log.hpp>
 #include <network/network.hpp>
 
+#if defined(_WIN32)
+#pragma comment(lib, "crypt32.lib")
+#include <string>
+
+#include <wincrypt.h>
+
+
+namespace
+{
+    // Validate the peer-presented certificate chain with the native Windows chain engine.
+    // Unlike OpenSSL, this supplies the system trust anchors, fetches any intermediate the
+    // server omitted via the certificate's AIA extension, and matches the hostname. Returns
+    // true only when the chain is trusted AND valid for `host`.
+    bool verifyChainWithWindows(X509_STORE_CTX* ctx, std::string const& host)
+    {
+        STACK_OF(X509)* const peerCerts{ X509_STORE_CTX_get0_untrusted(ctx) };
+        X509* const           leaf{ X509_STORE_CTX_get0_cert(ctx) };
+        if (nullptr == leaf)
+        {
+            logErr() << "TLS certificate is missing.";
+            return false;
+        }
+
+        // In-memory store holding the certs the server actually sent, so the chain engine can
+        // use any intermediates it did provide (and AIA-fetch the ones it did not).
+        HCERTSTORE const winStore{
+            CertOpenStore(CERT_STORE_PROV_MEMORY, X509_ASN_ENCODING, 0, CERT_STORE_CREATE_NEW_FLAG, nullptr)
+        };
+        if (nullptr == winStore)
+        {
+            logErr() << "Cannot allocate the Windows certificate store.";
+            return false;
+        }
+
+        auto addCert{ [&winStore](X509* x509) -> PCCERT_CONTEXT
+        {
+            unsigned char* der{ nullptr };
+            int const      len{ i2d_X509(x509, &der) };
+            PCCERT_CONTEXT context{ nullptr };
+            if (0 < len)
+            {
+                CertAddEncodedCertificateToStore(
+                    winStore, X509_ASN_ENCODING, der, static_cast<DWORD>(len), CERT_STORE_ADD_ALWAYS, &context);
+            }
+            if (nullptr != der)
+            {
+                OPENSSL_free(der);
+            }
+            return context;
+        } };
+
+        int const peerCount{ nullptr != peerCerts ? sk_X509_num(peerCerts) : 0 };
+        for (int i{ 0 }; i < peerCount; ++i)
+        {
+            if (PCCERT_CONTEXT const c{ addCert(sk_X509_value(peerCerts, i)) }; nullptr != c)
+            {
+                CertFreeCertificateContext(c);
+            }
+        }
+
+        PCCERT_CONTEXT const leafContext{ addCert(leaf) };
+        if (nullptr == leafContext)
+        {
+            logErr() << "Cannot encode the TLS leaf certificate.";
+            CertCloseStore(winStore, 0);
+            return false;
+        }
+
+        LPSTR           serverAuth[]{ const_cast<LPSTR>(szOID_PKIX_KP_SERVER_AUTH) };
+        CERT_CHAIN_PARA chainPara{};
+        chainPara.cbSize                                    = sizeof(chainPara);
+        chainPara.RequestedUsage.dwType                     = USAGE_MATCH_TYPE_AND;
+        chainPara.RequestedUsage.Usage.cUsageIdentifier     = 1;
+        chainPara.RequestedUsage.Usage.rgpszUsageIdentifier = serverAuth;
+
+        // hChainEngine = nullptr -> default engine (system roots + AIA fetch of a missing
+        // intermediate). No revocation flags -> no CRL/OCSP network dependency.
+        PCCERT_CHAIN_CONTEXT chainContext{ nullptr };
+        BOOL const           built{ CertGetCertificateChain(
+            nullptr, leafContext, nullptr, winStore, &chainPara, CERT_CHAIN_CACHE_END_CERT, nullptr, &chainContext) };
+
+        bool verified{ false };
+        if (FALSE != built && nullptr != chainContext)
+        {
+            std::wstring wideHost{ host.begin(), host.end() };
+
+            SSL_EXTRA_CERT_CHAIN_POLICY_PARA sslPara{};
+            sslPara.cbSize         = sizeof(sslPara);
+            sslPara.dwAuthType     = AUTHTYPE_SERVER;
+            sslPara.pwszServerName = wideHost.empty() ? nullptr : wideHost.data();
+
+            CERT_CHAIN_POLICY_PARA policyPara{};
+            policyPara.cbSize            = sizeof(policyPara);
+            policyPara.pvExtraPolicyPara = &sslPara;
+
+            CERT_CHAIN_POLICY_STATUS policyStatus{};
+            policyStatus.cbSize = sizeof(policyStatus);
+
+            if (FALSE != CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, chainContext, &policyPara, &policyStatus))
+            {
+                verified = (0 == policyStatus.dwError);
+                if (false == verified)
+                {
+                    logErr() << "TLS certificate chain rejected by Windows for " << host << " (status "
+                             << policyStatus.dwError << ").";
+                }
+            }
+        }
+        else
+        {
+            logErr() << "Windows could not build a certificate chain for " << host << " (error "
+                     << static_cast<unsigned long>(GetLastError()) << ").";
+        }
+
+        if (nullptr != chainContext)
+        {
+            CertFreeCertificateChain(chainContext);
+        }
+        CertFreeCertificateContext(leafContext);
+        CertCloseStore(winStore, 0);
+        return verified;
+    }
+}
+#endif
+
 
 void network::NetworkTCPClient::asyncReceive()
 {
@@ -35,6 +160,18 @@ void network::NetworkTCPClient::asyncReceive()
 
 bool network::NetworkTCPClient::onVerifySSL(bool preverified, boost_verify_context& ctx)
 {
+#if defined(_WIN32)
+    // OpenSSL has no trust anchors on Windows (see doSecureConnection), so `preverified`
+    // is always false here. The real trust decision is delegated to the Windows chain
+    // engine, made once at the leaf (depth 0); let the higher chain levels pass so OpenSSL
+    // keeps walking down to the leaf.
+    (void) preverified;
+    if (0 != X509_STORE_CTX_get_error_depth(ctx.native_handle()))
+    {
+        return true;
+    }
+    return verifyChainWithWindows(ctx.native_handle(), host);
+#else
     // OpenSSL's chain / expiry / CA verification must pass first. The previous
     // implementation discarded `preverified` and returned true for any cert that
     // merely existed, which fully bypassed TLS authentication and let a MITM
@@ -62,6 +199,7 @@ bool network::NetworkTCPClient::onVerifySSL(bool preverified, boost_verify_conte
     }
 
     return true;
+#endif
 }
 
 

--- a/sources/network/network_callback.cpp
+++ b/sources/network/network_callback.cpp
@@ -158,14 +158,13 @@ void network::NetworkTCPClient::asyncReceive()
 }
 
 
-bool network::NetworkTCPClient::onVerifySSL(bool preverified, boost_verify_context& ctx)
+bool network::NetworkTCPClient::onVerifySSL([[maybe_unused]] bool preverified, boost_verify_context& ctx)
 {
 #if defined(_WIN32)
     // OpenSSL has no trust anchors on Windows (see doSecureConnection), so `preverified`
     // is always false here. The real trust decision is delegated to the Windows chain
     // engine, made once at the leaf (depth 0); let the higher chain levels pass so OpenSSL
     // keeps walking down to the leaf.
-    (void) preverified;
     if (0 != X509_STORE_CTX_get_error_depth(ctx.native_handle()))
     {
         return true;


### PR DESCRIPTION
## Problem

On Windows the miner seeded OpenSSL only with the `ROOT` store. OpenSSL has no AIA fetching, so a pool that serves an **incomplete chain** (leaf only, omitting the intermediate) fails verification even though Windows trusts the certificate — a very common pool misconfiguration. Concrete case: `pool.woolypooly.com:3106` (TLS-only) ships the leaf without the Sectigo R36 intermediate, so `--ssl=true` failed with `TLS certificate chain verification failed` / `Cannot connect to pool with SSL option`.

## Fix

Hand the whole-chain trust decision to the native Windows chain engine, which supplies the system roots, AIA-fetches a missing intermediate, and validates the hostname — the same path Schannel/WinHTTP use.

- **`doSecureConnection`**: no longer seeds an OpenSSL trust store on Windows. `verify_peer` stays set so the callback still runs; the empty OpenSSL store just makes `preverified` always false (expected). Linux path unchanged (default paths + `ca-certificates.crt` + `SSL_CERT_FILE`).
- **`onVerifySSL`**: on Windows, defer to the leaf (depth 0) and call the new `verifyChainWithWindows()`; let higher chain levels pass so OpenSSL walks down to the leaf. Other platforms keep the OpenSSL `preverified` + `host_name_verification` path.
- **`verifyChainWithWindows`**: DER-encodes the peer-sent certs into an in-memory `HCERTSTORE`, calls `CertGetCertificateChain` (default engine = system roots + AIA fetch; no revocation flags = no CRL/OCSP network dependency), then `CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL)` to validate the chain **and** the hostname. Requires the `serverAuth` EKU. Frees the chain/contexts/store on every path.
- Moved the `crypt32` pragma + `wincrypt.h` include into `network_callback.cpp` (where they are now used) and dropped them from `network.cpp`.

More robust than seeding the cached `CA` store: it does not depend on the intermediate already being cached, so it works on a fresh machine and on the first connection.

## Security

Strictly tightens verification. Depth-0 delegation is safe — OpenSSL always invokes the callback at depth 0 (leaf) last, so the authoritative decision is made there; untrusted-root / self-signed / expired / name-mismatch all surface as a non-zero `dwError` and are rejected.

## Validation

- Compiles under the clang-cl cross-toolchain (`docker-build.ps1 -Os windows-cross -Gpu amd`).
- **Live-verified**: connecting with `--ssl=true` to `pool.woolypooly.com:3106` now reaches `Stratum connected!` and exchanges data over TLS, where the `ROOT`-only build failed.

## Notes

- No revocation checking (deliberate, avoids a CRL/OCSP network dependency; matches prior behavior).
- First handshake to an incomplete-chain pool may briefly block while Windows AIA-fetches the intermediate (then cached).