### PR TITLE
fix(autolykos): mine and submit accepted shares on NiceHash (boundaryU64, DAG overflow, hostHeader)

### DIFF
--- a/sources/algo/autolykos/autolykos_mhssamadani.cpp
+++ b/sources/algo/autolykos/autolykos_mhssamadani.cpp
@@ -460,6 +460,9 @@ bool algo::autolykos_v2::mhssamadani::isValidShare(
     HexStrToBigEndian(n_str, algo::autolykos_v2::NONCE_SIZE_8 * 2u, beN, algo::autolykos_v2::NONCE_SIZE_8);
 
     ///////////////////////////////////////////////////////////////////////////
+    // `height` arrives already byte-swapped to big-endian (callers pass
+    // algo::be::uint32(blockNumber)), so BigEndianToHexStr -> HexStrToBigEndian
+    // round-trips it to the canonical big-endian Ints.toByteArray(height) in beH.
     BigEndianToHexStr(height, HEIGHT_SIZE, h_str);
 
     ///////////////////////////////////////////////////////////////////////////

--- a/sources/algo/autolykos/cuda/dag.cuh
+++ b/sources/algo/autolykos/cuda/dag.cuh
@@ -76,7 +76,12 @@ void autolykos_v2_fill_dag(
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ((uint8_t *)hashes)[tid * 32 + 31] = 0;
+    // (uint64_t) cast is required: tid*32 overflows 32-bit for tid >= 2^27 (the 4 GiB
+    // byte boundary), silently retargeting this zeroing write to a low element and
+    // leaving the high elements' top byte = H[0] instead of 0 -- corrupting the verify
+    // sum (pool "Share above target"). Mirrors the OpenCL fix in autolykos_v2_dag.cl.
+    // luminousmining/miner#159 -- NOT yet verified on NVIDIA hardware.
+    ((uint8_t *)hashes)[(uint64_t)tid * 32 + 31] = 0;
 }
 
 

--- a/sources/algo/autolykos/opencl/autolykos_v2_dag.cl
+++ b/sources/algo/autolykos/opencl/autolykos_v2_dag.cl
@@ -79,5 +79,10 @@ void autolykos_v2_build_dag(
     {
         ((__global ulong *)dag)[(tid + 1) * 4 - i - 1] = as_ulong(as_uchar8(h[i]).s76543210);
     }
-    ((__global uchar *)dag)[tid * 32 + 31] = 0;
+    // (ulong) cast is required: tid*32 overflows 32-bit for tid >= 2^27 (the 4 GiB
+    // byte boundary), which silently retargets this zeroing write to a low element
+    // and leaves the high elements' top byte = H[0] instead of 0 -- corrupting the
+    // verify kernel's element sum. See ResolverAutolykosv2AmdTest.dagFullyGeneratedAtLiveHeight1803848.
+    // The CUDA path (cuda/dag.cuh) has the same overflow: luminousmining/miner#159.
+    ((__global uchar *)dag)[(ulong)tid * 32 + 31] = 0;
 }

--- a/sources/algo/autolykos/opencl/autolykos_v2_search.cl
+++ b/sources/algo/autolykos/opencl/autolykos_v2_search.cl
@@ -75,10 +75,14 @@ void autolykos_v2_search(
 
         //--------------------------read hash from lookup
         uint tmpL;
+        // (ulong) cast is required: h3*32 overflows 32-bit for h3 >= 2^27, which would
+        // read the wrong DAG element (and thus a wrong first-hash element f) for any
+        // nonce whose seed index lands in the upper part of a >4 GiB table.
+        ulong const dagByteBase = (ulong)h3 * 32;
         #pragma unroll 8
         for (int i = 0; i < 32; ++i)
         {
-            ((uchar *)r)[31-i] = ((__global uchar const* const)dag)[h3 * 32 + i];
+            ((uchar *)r)[31-i] = ((__global uchar const* const)dag)[dagByteBase + i];
         }
 
         B2B_IV(aux);

--- a/sources/algo/tests/autolykos.cpp
+++ b/sources/algo/tests/autolykos.cpp
@@ -26,8 +26,9 @@ TEST(AutolykosV2CpuShare, acceptsCanonicalErgoVectorHeight614400)
     // Build the boundary through the same pipeline the live stratum uses
     // (StratumAutolykosV2::onMiningNotify), so isValidShare sees the target in the
     // little-endian layout it expects.
-    algo::hash256 boundary{ algo::toHash2<algo::hash256, algo::hash512>(algo::toLittleEndian<algo::hash512>(
-        algo::decimalToHash<algo::hash512>("7067388259113537318333190002971674063283542741642755394446115914399301849"))) };
+    algo::hash256 boundary{ algo::toHash2<algo::hash256, algo::hash512>(
+        algo::toLittleEndian<algo::hash512>(algo::decimalToHash<algo::hash512>(
+            "7067388259113537318333190002971674063283542741642755394446115914399301849"))) };
 
     // isValidShare takes the height already byte-swapped to big-endian, exactly as
     // the resolver passes it (parameters.hostHeight = algo::be::uint32(blockNumber)).

--- a/sources/algo/tests/autolykos.cpp
+++ b/sources/algo/tests/autolykos.cpp
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+
+#include <algo/autolykos/autolykos.hpp>
+#include <algo/bitwise.hpp>
+#include <algo/hash.hpp>
+#include <algo/hash_utils.hpp>
+
+
+// Canonical Autolykos2 proof-of-work vector from the Ergo reference client
+// (AutolykosPowSchemeSpec, "test vectors for first increase in N value", height
+// 614,400, protocol version 2; algorithm sigma/pow/Autolykos2PowValidation.scala).
+// Re-derived independently against Blake2b256:
+//   msg    = 548c3e60..7e864f  (Blake2b256 of the header without PoW)
+//   nonce  = 0x0000000000003105
+//   height = 614400 -> N = calcN = 70464240
+//   hit    = 0002fcb113fe65e5754959872dfdbffea0489bf830beb4961ddc0e9e66a1412a
+//   b      = 7067388259..301849  (target at difficulty 16384)
+// hit < b, so nonce 0x3105 is a valid solution. The CPU re-check used by
+// ResolverAmdAutolykosV2::getResultCache to filter GPU candidates before submit
+// must therefore accept it. (The matching GPU pipeline is pinned by
+// ResolverAutolykosv2AmdTest.acceptsCanonicalErgoVectorHeight614400.)
+TEST(AutolykosV2CpuShare, acceptsCanonicalErgoVectorHeight614400)
+{
+    algo::hash256 header{ algo::toHash256("548c3e602a8f36f8f2738f5f643b02425038044d98543a51cabaa9785e7e864f") };
+
+    // Build the boundary through the same pipeline the live stratum uses
+    // (StratumAutolykosV2::onMiningNotify), so isValidShare sees the target in the
+    // little-endian layout it expects.
+    algo::hash256 boundary{ algo::toHash2<algo::hash256, algo::hash512>(algo::toLittleEndian<algo::hash512>(
+        algo::decimalToHash<algo::hash512>("7067388259113537318333190002971674063283542741642755394446115914399301849"))) };
+
+    // isValidShare takes the height already byte-swapped to big-endian, exactly as
+    // the resolver passes it (parameters.hostHeight = algo::be::uint32(blockNumber)).
+    EXPECT_TRUE(algo::autolykos_v2::mhssamadani::isValidShare(header, boundary, 0x3105ull, algo::be::uint32(614400u)));
+}

--- a/sources/benchmark/cuda/autolykos_v2/autolykos_v2_mhssamadani_prehash.cu
+++ b/sources/benchmark/cuda/autolykos_v2/autolykos_v2_mhssamadani_prehash.cu
@@ -210,7 +210,9 @@ void autolykos_v2_mhssamadi_init_prehash(
         {
             store64(&(((uint64_t*)hashes)[(tid + 1) * 4 - i - 1]), h[i]);
         }
-        ((uint8_t*)hashes)[tid * 32 + 31] = 0;
+        // (uint64_t) cast: tid*32 overflows 32-bit for tid >= 2^27 (4 GiB). Same bug as
+        // cuda/dag.cuh -- luminousmining/miner#159. Untested on NVIDIA hardware.
+        ((uint8_t*)hashes)[(uint64_t)tid * 32 + 31] = 0;
     }
 }
 

--- a/sources/benchmark/cuda/autolykos_v2/autolykos_v2_prehash_v1.cu
+++ b/sources/benchmark/cuda/autolykos_v2/autolykos_v2_prehash_v1.cu
@@ -84,7 +84,9 @@ void kernel_autolykos_v2_prehash_lm1(
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ((uint8_t*)hashes)[tid * 32 + 31] = 0;
+    // (uint64_t) cast: tid*32 overflows 32-bit for tid >= 2^27 (4 GiB). Same bug as
+    // cuda/dag.cuh -- luminousmining/miner#159. Untested on NVIDIA hardware.
+    ((uint8_t*)hashes)[(uint64_t)tid * 32 + 31] = 0;
 }
 
 

--- a/sources/resolver/amd/autolykos_v2.cpp
+++ b/sources/resolver/amd/autolykos_v2.cpp
@@ -30,9 +30,7 @@ resolver::ResolverAmdAutolykosV2::~ResolverAmdAutolykosV2()
 bool resolver::ResolverAmdAutolykosV2::updateMemory(stratum::StratumJobInfo const& jobInfo)
 {
     ////////////////////////////////////////////////////////////////////////////
-    if (   nullptr == clContext
-        || nullptr == clQueue[0]
-        || nullptr == clQueue[1]) [[unlikely]]
+    if (nullptr == clContext || nullptr == clQueue[0] || nullptr == clQueue[1]) [[unlikely]]
     {
         return false;
     }

--- a/sources/resolver/amd/autolykos_v2.cpp
+++ b/sources/resolver/amd/autolykos_v2.cpp
@@ -114,11 +114,6 @@ bool resolver::ResolverAmdAutolykosV2::updateConstants(stratum::StratumJobInfo c
         return false;
     }
 
-    ////////////////////////////////////////////////////////////////////////////
-    // getResultCache() re-checks GPU candidates on the CPU via isValidShare(), which
-    // reads parameters.hostHeader. It must track the job header (the NVIDIA resolver
-    // does the same in updateMemory); without this it stayed zero-initialised, so the
-    // CPU re-check hashed the wrong header and rejected every valid GPU share.
     parameters.hostHeader = jobInfo.headerHash;
 
     uint32_t const* const header{ jobInfo.headerHash.word32 };

--- a/sources/resolver/amd/autolykos_v2.cpp
+++ b/sources/resolver/amd/autolykos_v2.cpp
@@ -117,6 +117,12 @@ bool resolver::ResolverAmdAutolykosV2::updateConstants(stratum::StratumJobInfo c
     }
 
     ////////////////////////////////////////////////////////////////////////////
+    // getResultCache() re-checks GPU candidates on the CPU via isValidShare(), which
+    // reads parameters.hostHeader. It must track the job header (the NVIDIA resolver
+    // does the same in updateMemory); without this it stayed zero-initialised, so the
+    // CPU re-check hashed the wrong header and rejected every valid GPU share.
+    parameters.hostHeader = jobInfo.headerHash;
+
     uint32_t const* const header{ jobInfo.headerHash.word32 };
     if (false == parameters.headerCache.setBufferDevice(clQueue[currentIndexStream], header))
     {

--- a/sources/resolver/amd/tests/autolykos_v2.cpp
+++ b/sources/resolver/amd/tests/autolykos_v2.cpp
@@ -189,8 +189,9 @@ TEST_F(ResolverAutolykosv2AmdTest, acceptsCanonicalErgoVectorHeight614400)
     // Build the boundary through the exact production pipeline (mirrors
     // StratumAutolykosV2::onMiningNotify) so the verify kernel sees the target in
     // the same little-endian layout it does live.
-    jobInfo.boundary = algo::toHash2<algo::hash256, algo::hash512>(algo::toLittleEndian<algo::hash512>(
-        algo::decimalToHash<algo::hash512>("7067388259113537318333190002971674063283542741642755394446115914399301849")));
+    jobInfo.boundary = algo::toHash2<algo::hash256, algo::hash512>(
+        algo::toLittleEndian<algo::hash512>(algo::decimalToHash<algo::hash512>(
+            "7067388259113537318333190002971674063283542741642755394446115914399301849")));
     jobInfo.boundaryU64 = algo::toUINT64(jobInfo.boundary);
 
     ASSERT_TRUE(resolver.updateMemory(jobInfo));

--- a/sources/resolver/amd/tests/autolykos_v2.cpp
+++ b/sources/resolver/amd/tests/autolykos_v2.cpp
@@ -28,7 +28,7 @@ struct ProbeResolverAmdAutolykosV2 : public resolver::ResolverAmdAutolykosV2
     // runs getResultCache(), which filters the raw nonces through isValidShare.)
     bool runSingleGroupRaw(algo::autolykos_v2::Result& out)
     {
-        uint32_t const blockDim{ algo::autolykos_v2::AMD_BLOCK_DIM };
+        uint32_t const          blockDim{ algo::autolykos_v2::AMD_BLOCK_DIM };
         cl::CommandQueue* const queue{ clQueue[currentIndexStream] };
 
         if (false == parameters.resultCache.resetBufferHost(queue))
@@ -37,14 +37,17 @@ struct ProbeResolverAmdAutolykosV2 : public resolver::ResolverAmdAutolykosV2
         }
 
         cl_int err{ CL_SUCCESS };
-        auto& clKernelSearch{ kernelGeneratorSearch.clKernel };
+        auto&  clKernelSearch{ kernelGeneratorSearch.clKernel };
         err |= clKernelSearch.setArg(0u, *(parameters.headerCache.getBuffer()));
         err |= clKernelSearch.setArg(1u, *(parameters.dagCache.getBuffer()));
         err |= clKernelSearch.setArg(2u, *(parameters.BHashes.getBuffer()));
         err |= clKernelSearch.setArg(3u, parameters.hostNonce);
         err |= clKernelSearch.setArg(4u, parameters.hostPeriod);
         err |= queue->enqueueNDRangeKernel(
-            clKernelSearch, cl::NullRange, cl::NDRange(blockDim, 1, 1), cl::NDRange(blockDim, 1, 1));
+            clKernelSearch,
+            cl::NullRange,
+            cl::NDRange(blockDim, 1, 1),
+            cl::NDRange(blockDim, 1, 1));
         err |= queue->finish();
         if (CL_SUCCESS != err)
         {
@@ -60,7 +63,10 @@ struct ProbeResolverAmdAutolykosV2 : public resolver::ResolverAmdAutolykosV2
         err |= clKernelVerify.setArg(5u, parameters.hostPeriod);
         err |= clKernelVerify.setArg(6u, parameters.hostHeight);
         err |= queue->enqueueNDRangeKernel(
-            clKernelVerify, cl::NullRange, cl::NDRange(blockDim, 1, 1), cl::NDRange(blockDim, 1, 1));
+            clKernelVerify,
+            cl::NullRange,
+            cl::NDRange(blockDim, 1, 1),
+            cl::NDRange(blockDim, 1, 1));
         err |= queue->finish();
         if (CL_SUCCESS != err)
         {
@@ -84,12 +90,15 @@ struct ProbeResolverAmdAutolykosV2 : public resolver::ResolverAmdAutolykosV2
         cl::Buffer staging(*clContext, CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR, algo::LEN_HASH_256);
         if (CL_SUCCESS
             != clQueue[currentIndexStream]->enqueueCopyBuffer(
-                *(parameters.dagCache.getBuffer()), staging, idx * algo::LEN_HASH_256, 0u, algo::LEN_HASH_256))
+                *(parameters.dagCache.getBuffer()),
+                staging,
+                idx * algo::LEN_HASH_256,
+                0u,
+                algo::LEN_HASH_256))
         {
             return false;
         }
-        if (CL_SUCCESS
-            != clQueue[currentIndexStream]->enqueueReadBuffer(staging, CL_TRUE, 0u, algo::LEN_HASH_256, out))
+        if (CL_SUCCESS != clQueue[currentIndexStream]->enqueueReadBuffer(staging, CL_TRUE, 0u, algo::LEN_HASH_256, out))
         {
             return false;
         }

--- a/sources/resolver/amd/tests/autolykos_v2.cpp
+++ b/sources/resolver/amd/tests/autolykos_v2.cpp
@@ -10,12 +10,100 @@
 #include <resolver/tests/amd.hpp>
 
 
+// Test-only subclass that runs the real dag/search/verify kernels but exposes the
+// RAW GPU result buffer -- i.e. the nonces the verify kernel itself accepts against
+// the boundary -- before getResultCache() re-filters them through the (divergent)
+// CPU mhssamadani::isValidShare. This lets a test assert what the GPU actually does.
+struct ProbeResolverAmdAutolykosV2 : public resolver::ResolverAmdAutolykosV2
+{
+    // Launches search + verify over a SINGLE work-group, so only nonces
+    // [base, base + AMD_BLOCK_DIM) are checked. With a real (tight) boundary this
+    // makes a single known-good nonce at tid 0 the only solution captured in the
+    // 4-slot result buffer, instead of being lost among the many solutions a full
+    // NONCES_PER_ITER sweep would find.
+    //
+    // The kernel argument order MUST mirror ResolverAmdAutolykosV2::executeSync(); if
+    // that launch sequence changes, update this in lockstep or the test silently
+    // exercises a stale path. (We can't reuse executeSync directly because it also
+    // runs getResultCache(), which filters the raw nonces through isValidShare.)
+    bool runSingleGroupRaw(algo::autolykos_v2::Result& out)
+    {
+        uint32_t const blockDim{ algo::autolykos_v2::AMD_BLOCK_DIM };
+        cl::CommandQueue* const queue{ clQueue[currentIndexStream] };
+
+        if (false == parameters.resultCache.resetBufferHost(queue))
+        {
+            return false;
+        }
+
+        cl_int err{ CL_SUCCESS };
+        auto& clKernelSearch{ kernelGeneratorSearch.clKernel };
+        err |= clKernelSearch.setArg(0u, *(parameters.headerCache.getBuffer()));
+        err |= clKernelSearch.setArg(1u, *(parameters.dagCache.getBuffer()));
+        err |= clKernelSearch.setArg(2u, *(parameters.BHashes.getBuffer()));
+        err |= clKernelSearch.setArg(3u, parameters.hostNonce);
+        err |= clKernelSearch.setArg(4u, parameters.hostPeriod);
+        err |= queue->enqueueNDRangeKernel(
+            clKernelSearch, cl::NullRange, cl::NDRange(blockDim, 1, 1), cl::NDRange(blockDim, 1, 1));
+        err |= queue->finish();
+        if (CL_SUCCESS != err)
+        {
+            return false;
+        }
+
+        auto& clKernelVerify{ kernelGeneratorVerify.clKernel };
+        err |= clKernelVerify.setArg(0u, *(parameters.boundaryCache.getBuffer()));
+        err |= clKernelVerify.setArg(1u, *(parameters.dagCache.getBuffer()));
+        err |= clKernelVerify.setArg(2u, *(parameters.BHashes.getBuffer()));
+        err |= clKernelVerify.setArg(3u, *(parameters.resultCache.getBuffer()));
+        err |= clKernelVerify.setArg(4u, parameters.hostNonce);
+        err |= clKernelVerify.setArg(5u, parameters.hostPeriod);
+        err |= clKernelVerify.setArg(6u, parameters.hostHeight);
+        err |= queue->enqueueNDRangeKernel(
+            clKernelVerify, cl::NullRange, cl::NDRange(blockDim, 1, 1), cl::NDRange(blockDim, 1, 1));
+        err |= queue->finish();
+        if (CL_SUCCESS != err)
+        {
+            return false;
+        }
+
+        return parameters.resultCache.getBufferHost(queue, &out);
+    }
+
+    // The header isValidShare re-checks against; must track jobInfo.headerHash.
+    algo::hash256 const& hostHeader() const
+    {
+        return parameters.hostHeader;
+    }
+
+    // Copy one 32-byte DAG element (HOST_NO_ACCESS device buffer) out via a small
+    // host-readable staging buffer, so a test can compare it to the canonical
+    // genElementV2 value and detect indices the fillDAG launch failed to write.
+    bool readDagElement(uint64_t const idx, uint8_t* const out)
+    {
+        cl::Buffer staging(*clContext, CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR, algo::LEN_HASH_256);
+        if (CL_SUCCESS
+            != clQueue[currentIndexStream]->enqueueCopyBuffer(
+                *(parameters.dagCache.getBuffer()), staging, idx * algo::LEN_HASH_256, 0u, algo::LEN_HASH_256))
+        {
+            return false;
+        }
+        if (CL_SUCCESS
+            != clQueue[currentIndexStream]->enqueueReadBuffer(staging, CL_TRUE, 0u, algo::LEN_HASH_256, out))
+        {
+            return false;
+        }
+        return true;
+    }
+};
+
+
 struct ResolverAutolykosv2AmdTest : public testing::Test
 {
-    stratum::StratumJobInfo          jobInfo{};
-    resolver::tests::Properties      properties{};
-    common::mocker::MockerStratum    stratum{};
-    resolver::ResolverAmdAutolykosV2 resolver{};
+    stratum::StratumJobInfo       jobInfo{};
+    resolver::tests::Properties   properties{};
+    common::mocker::MockerStratum stratum{};
+    ProbeResolverAmdAutolykosV2   resolver{};
 
     ResolverAutolykosv2AmdTest()
     {
@@ -62,8 +150,103 @@ TEST_F(ResolverAutolykosv2AmdTest, findNonce)
 
     ASSERT_TRUE(resolver.updateMemory(jobInfo));
     ASSERT_TRUE(resolver.updateConstants(jobInfo));
+
+    // updateConstants must propagate the job header to the CPU re-check
+    // (isValidShare reads parameters.hostHeader); otherwise every valid GPU share
+    // is hashed against a stale header and dropped before submit.
+    EXPECT_TRUE(algo::isEqual(resolver.hostHeader(), jobInfo.headerHash));
+
     ASSERT_TRUE(resolver.executeSync(jobInfo));
     resolver.submit(&stratum);
 
     EXPECT_FALSE(stratum.paramSubmit.empty());
+}
+
+
+// Canonical Autolykos2 proof-of-work vector from the Ergo reference client
+// (AutolykosPowSchemeSpec, "test vectors for first increase in N value", height
+// 614,400, protocol version 2; algorithm sigma/pow/Autolykos2PowValidation.scala).
+// Re-derived independently against Blake2b256 to confirm:
+//   msg    = 548c3e60..7e864f  (Blake2b256 of the header without PoW)
+//   nonce  = 0x0000000000003105
+//   height = 614400 -> N = calcN = 70464240
+//   hit    = 0002fcb113fe65e5754959872dfdbffea0489bf830beb4961ddc0e9e66a1412a
+//   b      = 7067388259...301849  (target at difficulty 16384)
+// hit < b, so nonce 0x3105 is a valid solution. With base nonce 0x3105 the search
+// kernel hashes exactly this nonce at tid 0, so a correct GPU pipeline MUST accept
+// it. This pins the dag/search/verify kernels to the canonical algorithm,
+// independent of the live stratum header/nonce/boundary plumbing.
+TEST_F(ResolverAutolykosv2AmdTest, acceptsCanonicalErgoVectorHeight614400)
+{
+    // N for the vector must match the reference (calcN(614400) == 70464240).
+    ASSERT_EQ(70464240u, algo::autolykos_v2::computePeriod(614400u));
+
+    jobInfo.headerHash = algo::toHash256("548c3e602a8f36f8f2738f5f643b02425038044d98543a51cabaa9785e7e864f");
+    jobInfo.blockNumber = 614400;
+    jobInfo.period = castU64(algo::autolykos_v2::computePeriod(614400u));
+    jobInfo.nonce = 0x3105ull; // tid 0 hashes nonce 0x0000000000003105
+
+    // Build the boundary through the exact production pipeline (mirrors
+    // StratumAutolykosV2::onMiningNotify) so the verify kernel sees the target in
+    // the same little-endian layout it does live.
+    jobInfo.boundary = algo::toHash2<algo::hash256, algo::hash512>(algo::toLittleEndian<algo::hash512>(
+        algo::decimalToHash<algo::hash512>("7067388259113537318333190002971674063283542741642755394446115914399301849")));
+    jobInfo.boundaryU64 = algo::toUINT64(jobInfo.boundary);
+
+    ASSERT_TRUE(resolver.updateMemory(jobInfo));
+    ASSERT_TRUE(resolver.updateConstants(jobInfo));
+
+    algo::autolykos_v2::Result raw{};
+    ASSERT_TRUE(resolver.runSingleGroupRaw(raw));
+
+    EXPECT_TRUE(raw.found);
+
+    bool canonicalFound{ false };
+    for (uint32_t i{ 0u }; i < raw.count && i < algo::autolykos_v2::MAX_RESULT; ++i)
+    {
+        if (0x3105ull == raw.nonces[i])
+        {
+            canonicalFound = true;
+        }
+    }
+    EXPECT_TRUE(canonicalFound);
+}
+
+
+// Verify the DAG is fully generated at a live mainnet height. At block 1803848 the
+// table is N = 216,430,305 elements = ~6.9 GB. Each element must equal the canonical
+// genElementV2(idx, height) = Blake2b256(idx_4BE | height_4BE | M)[1..31], which the
+// dag kernel stores as the 32-byte hash byte-reversed with the last byte zeroed.
+// Expected values below were computed independently (Bun blake2b256). A low index is
+// always written; the cross-4GB / end indices expose whether the fillDAG launch (or
+// the single >4GB buffer's 32-bit addressing) drops the high part of the table --
+// the cause of the live GPU "Share above target" false positives.
+TEST_F(ResolverAutolykosv2AmdTest, dagFullyGeneratedAtLiveHeight1803848)
+{
+    ASSERT_EQ(216430305u, algo::autolykos_v2::computePeriod(1803848u));
+
+    jobInfo.headerHash = algo::toHash256("5128c31fac60b942c1a9ce1441017ec4b7a54d71bf6f88281bb37a3aa1ac23f8");
+    jobInfo.blockNumber = 1803848;
+    jobInfo.period = castU64(algo::autolykos_v2::computePeriod(1803848u));
+    jobInfo.nonce = 0ull;
+    jobInfo.boundary = algo::toHash256("ff"); // unused for DAG content
+    jobInfo.boundaryU64 = algo::toUINT64(jobInfo.boundary);
+
+    ASSERT_TRUE(resolver.updateMemory(jobInfo));
+
+    auto const elemHex{ [&](uint64_t const idx) -> std::string
+                        {
+                            algo::hash256 e{};
+                            EXPECT_TRUE(resolver.readDagElement(idx, e.ubytes));
+                            return algo::toHex(e);
+                        } };
+
+    // Low index -- written by any launch; sanity that DAG build works at all.
+    EXPECT_EQ("7d5ed6ebf4dffa8217b77244abecefe1aaa95f16136d7747a555ffbca7d84c00", elemHex(1000ull));
+    // Straddle the 4 GiB element boundary (134,217,728 = 4 GiB / 32).
+    EXPECT_EQ("2b5bde4ff95f66665f1c0fe01af5f69e27c1456a25ba54abb9837b80c4bc9900", elemHex(134217727ull));
+    EXPECT_EQ("a24366848eef17763bd09ec7384737abb3c0f887739eac2096d3fb2713ae1000", elemHex(134217728ull));
+    EXPECT_EQ("346822e39669c7307ece71ea84c804b25b31153e9733549035e5cc2304f2e700", elemHex(134218728ull));
+    // Last element of the table.
+    EXPECT_EQ("58006852cbe55c358518e6ca9f5f21e20f087335bcbc88280bc3761ec3bae400", elemHex(216430304ull));
 }

--- a/sources/stratum/autolykos_v2.cpp
+++ b/sources/stratum/autolykos_v2.cpp
@@ -78,6 +78,10 @@ void stratum::StratumAutolykosV2::onMiningNotify(boost::json::object const& root
     jobInfo.headerHash = algo::toHash256(params.at(2).as_string().c_str());
     jobInfo.boundary = algo::toHash2<algo::hash256, algo::hash512>(
         algo::toLittleEndian<algo::hash512>(algo::decimalToHash<algo::hash512>(params.at(6).as_string().c_str())));
+    // NiceHash sends no mining.set_difficulty/set_target -- the per-job target is
+    // embedded here in params[6]. Derive boundaryU64 from it (mirroring
+    // onMiningSetDifficulty) so isValidJob() does not drop the job for a 0 boundary.
+    jobInfo.boundaryU64 = algo::toUINT64(jobInfo.boundary);
 
     jobInfo.cleanJob = params.at(8).as_bool();
 

--- a/sources/stratum/autolykos_v2.cpp
+++ b/sources/stratum/autolykos_v2.cpp
@@ -78,9 +78,6 @@ void stratum::StratumAutolykosV2::onMiningNotify(boost::json::object const& root
     jobInfo.headerHash = algo::toHash256(params.at(2).as_string().c_str());
     jobInfo.boundary = algo::toHash2<algo::hash256, algo::hash512>(
         algo::toLittleEndian<algo::hash512>(algo::decimalToHash<algo::hash512>(params.at(6).as_string().c_str())));
-    // NiceHash sends no mining.set_difficulty/set_target -- the per-job target is
-    // embedded here in params[6]. Derive boundaryU64 from it (mirroring
-    // onMiningSetDifficulty) so isValidJob() does not drop the job for a 0 boundary.
     jobInfo.boundaryU64 = algo::toUINT64(jobInfo.boundary);
 
     jobInfo.cleanJob = params.at(8).as_bool();

--- a/sources/stratum/tests/autolykos_v2_notify.cpp
+++ b/sources/stratum/tests/autolykos_v2_notify.cpp
@@ -1,0 +1,101 @@
+#include <cstdint>
+
+#include <boost/json.hpp>
+#include <gtest/gtest.h>
+
+#include <algo/hash.hpp>
+#include <algo/hash_utils.hpp>
+#include <stratum/autolykos_v2.hpp>
+#include <stratum/stratum.hpp>
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Regression coverage for the NiceHash Autolykos2 boundary fix.
+//
+// Bug: NiceHash autolykos sends NO mining.set_difficulty / mining.set_target --
+// the per-job target arrives embedded in mining.notify (params[6], a big decimal
+// boundary). onMiningNotify() parsed jobInfo.boundary (hash256) from it but never
+// set jobInfo.boundaryU64. Only onMiningSetDifficulty() did, and NiceHash never
+// calls it, so boundaryU64 stayed 0. Stratum::isValidJob() rejects any job with
+// boundaryU64 == 0 ("Boundary U64 == 0ull"), so every job was silently dropped
+// and the GPU never started hashing.
+//
+// The fix recomputes boundaryU64 from the notify boundary, mirroring the other
+// stratums (ethash/progpow/blake3) whose notify handlers always do so.
+//
+// No network needed: updateJob() is overridden to a no-op so onMiningNotify()'s
+// only observable effect is the mutated jobInfo.
+////////////////////////////////////////////////////////////////////////////////
+
+
+namespace
+{
+    struct ProbeStratumAutolykosV2 final : public stratum::StratumAutolykosV2
+    {
+        void updateJob() override
+        {
+            // Skip dispatch/callback; the test inspects jobInfo directly.
+        }
+    };
+
+
+    // A NiceHash-style mining.notify with the target embedded in params[6] and no
+    // preceding set_difficulty. Layout matches StratumAutolykosV2::onMiningNotify:
+    // [jobID, blockNumber, headerHash, "", "", _, boundaryDecimal, "", cleanJob].
+    boost::json::object makeNiceHashNotify()
+    {
+        boost::json::object root;
+        root["method"] = "mining.notify";
+        root["params"] = boost::json::array{
+            "0000000073fd34ab",                                                 // 0: job id
+            1803772,                                                            // 1: block number
+            "6f109ba5226d1e0814cdeec79f1231d1d48196b5979a6d816e3621a1ef47ad80", // 2: header hash
+            "",                                                                 // 3
+            "",                                                                 // 4
+            2,                                                                  // 5
+            "107839786668602559178668060348078522694548577690162289924414440996863", // 6: boundary
+            "",                                                                 // 7
+            true                                                                // 8: clean job
+        };
+        return root;
+    }
+}
+
+
+struct StratumAutolykosV2NotifyTest : public testing::Test
+{
+    StratumAutolykosV2NotifyTest() = default;
+    ~StratumAutolykosV2NotifyTest() override = default;
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+// The NiceHash notify carries the target in params[6] and no set_difficulty
+// arrives first; boundaryU64 must still be populated or isValidJob() drops the
+// job and the GPU never hashes.
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(StratumAutolykosV2NotifyTest, NotifyEmbeddedBoundaryPopulatesBoundaryU64)
+{
+    ProbeStratumAutolykosV2 stratum{};
+
+    stratum.onMiningNotify(makeNiceHashNotify());
+
+    EXPECT_FALSE(algo::isHashEmpty(stratum.jobInfo.boundary));
+    EXPECT_NE(0ull, stratum.jobInfo.boundaryU64);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// The per-job notify boundary is authoritative: boundaryU64 must be derived from
+// the same hash256 the resolver consumes, not left over from a prior difficulty.
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(StratumAutolykosV2NotifyTest, NotifyBoundaryU64MatchesNotifyBoundaryHash)
+{
+    ProbeStratumAutolykosV2 stratum{};
+
+    stratum.onMiningNotify(makeNiceHashNotify());
+
+    EXPECT_EQ(algo::toUINT64(stratum.jobInfo.boundary), stratum.jobInfo.boundaryU64);
+}

--- a/sources/stratum/tests/autolykos_v2_notify.cpp
+++ b/sources/stratum/tests/autolykos_v2_notify.cpp
@@ -28,44 +28,41 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 
-namespace
+struct ProbeStratumAutolykosV2 final : public stratum::StratumAutolykosV2
 {
-    struct ProbeStratumAutolykosV2 final : public stratum::StratumAutolykosV2
+    void updateJob() override
     {
-        void updateJob() override
-        {
-            // Skip dispatch/callback; the test inspects jobInfo directly.
-        }
-    };
-
-
-    // A NiceHash-style mining.notify with the target embedded in params[6] and no
-    // preceding set_difficulty. Layout matches StratumAutolykosV2::onMiningNotify:
-    // [jobID, blockNumber, headerHash, "", "", _, boundaryDecimal, "", cleanJob].
-    boost::json::object makeNiceHashNotify()
-    {
-        boost::json::object root;
-        root["method"] = "mining.notify";
-        root["params"] = boost::json::array{
-            "0000000073fd34ab",                                                      // 0: job id
-            1803772,                                                                 // 1: block number
-            "6f109ba5226d1e0814cdeec79f1231d1d48196b5979a6d816e3621a1ef47ad80",      // 2: header hash
-            "",                                                                      // 3
-            "",                                                                      // 4
-            2,                                                                       // 5
-            "107839786668602559178668060348078522694548577690162289924414440996863", // 6: boundary
-            "",                                                                      // 7
-            true                                                                     // 8: clean job
-        };
-        return root;
+        // Skip dispatch/callback; the test inspects jobInfo directly.
     }
+};
+
+
+// A NiceHash-style mining.notify with the target embedded in params[6] and no
+// preceding set_difficulty. Layout matches StratumAutolykosV2::onMiningNotify:
+// [jobID, blockNumber, headerHash, "", "", _, boundaryDecimal, "", cleanJob].
+boost::json::object makeNiceHashNotify()
+{
+    boost::json::object root;
+    root["method"] = "mining.notify";
+    root["params"] = boost::json::array{
+        "0000000073fd34ab",                                                      // 0: job id
+        1803772,                                                                 // 1: block number
+        "6f109ba5226d1e0814cdeec79f1231d1d48196b5979a6d816e3621a1ef47ad80",      // 2: header hash
+        "",                                                                      // 3
+        "",                                                                      // 4
+        2,                                                                       // 5
+        "107839786668602559178668060348078522694548577690162289924414440996863", // 6: boundary
+        "",                                                                      // 7
+        true                                                                     // 8: clean job
+    };
+    return root;
 }
 
 
 struct StratumAutolykosV2NotifyTest : public testing::Test
 {
     StratumAutolykosV2NotifyTest() = default;
-    ~StratumAutolykosV2NotifyTest() override = default;
+    ~StratumAutolykosV2NotifyTest() = default;
 };
 
 

--- a/sources/stratum/tests/autolykos_v2_notify.cpp
+++ b/sources/stratum/tests/autolykos_v2_notify.cpp
@@ -47,15 +47,15 @@ namespace
         boost::json::object root;
         root["method"] = "mining.notify";
         root["params"] = boost::json::array{
-            "0000000073fd34ab",                                                 // 0: job id
-            1803772,                                                            // 1: block number
-            "6f109ba5226d1e0814cdeec79f1231d1d48196b5979a6d816e3621a1ef47ad80", // 2: header hash
-            "",                                                                 // 3
-            "",                                                                 // 4
-            2,                                                                  // 5
+            "0000000073fd34ab",                                                      // 0: job id
+            1803772,                                                                 // 1: block number
+            "6f109ba5226d1e0814cdeec79f1231d1d48196b5979a6d816e3621a1ef47ad80",      // 2: header hash
+            "",                                                                      // 3
+            "",                                                                      // 4
+            2,                                                                       // 5
             "107839786668602559178668060348078522694548577690162289924414440996863", // 6: boundary
-            "",                                                                 // 7
-            true                                                                // 8: clean job
+            "",                                                                      // 7
+            true                                                                     // 8: clean job
         };
         return root;
     }


### PR DESCRIPTION
## Summary
Autolykos2 on NiceHash never started hashing, and once that was fixed it never landed an accepted share. This fixes the full chain end-to-end. **AMD is live-verified** on an RX 9070 XT against `autolykos.eu.nicehash.com`: **3 accepted shares, 0 rejected, 0 "above target"**. The CUDA path gets the analogous fix but is **untested** (see Caveats).

## Root causes fixed
1. **Jobs never dispatched.** NiceHash sends no `mining.set_difficulty`; the per-job target is embedded in `mining.notify` params[6]. `onMiningNotify` set `jobInfo.boundary` but not `jobInfo.boundaryU64`, so `isValidJob()` dropped every job (`Boundary U64 == 0ull`). Derive `boundaryU64` from the notify target.
2. **"Share above target" false positives.** A 32-bit index overflow in the AMD DAG kernels -- `dag.cl` `tid*32+31` (last-byte zeroing) and `search.cl` `h3*32+i` (lookup) -- wraps for index >= 2^27 (the 4 GiB boundary). On a live table (`N ~ 216M`, ~6.9 GB) this left every element above 4 GiB with a non-zero top byte and made search read the wrong element, corrupting the verify sum. Cast both indices to 64-bit.
3. **Every real share dropped before submit.** `parameters.hostHeader` was never assigned in the AMD resolver (the NVIDIA resolver sets it), so the CPU re-check in `getResultCache` (`isValidShare`) hashed candidates against a zero header and rejected them all. Set it in `updateConstants`.
4. **CUDA parity (untested).** The same overflow exists in `cuda/dag.cuh` and two benchmark prehash kernels; fixed with the same cast. Tracked in #159.

## Changes
- `stratum/autolykos_v2.cpp` -- derive `boundaryU64` from the notify-embedded target.
- `algo/autolykos/opencl/{dag,search}.cl` -- 64-bit DAG indexing.
- `resolver/amd/autolykos_v2.cpp` -- propagate `hostHeader` in `updateConstants`.
- `algo/autolykos/cuda/dag.cuh`, `benchmark/cuda/autolykos_v2/*prehash*.cu` -- 64-bit indexing (untested on NVIDIA).
- Tests: stratum notify (`boundaryU64 != 0`), CPU `isValidShare` canonical Ergo vector, AMD GPU canonical vector (raw verify buffer), AMD DAG full-coverage across the 4 GiB boundary at a live height, and a `findNonce` guard that `updateConstants` propagates `hostHeader`.

## Testing
- 7 autolykos unit tests green (cross-built, run on RX 9070 XT / gfx1201).
- Live: NiceHash autolykos -- 3 accepted, 0 rejected.

## Caveats / follow-ups
- **CUDA fixes unverified** (no NVIDIA hardware) -- see #159.
- `format-check` not run locally (no clang-format available); manual review clean.
- Pre-existing, out of scope: the iGPU as `Device[1]` crashes the process on autolykos (workaround: `--devices_disable 1`).
