### PR TITLE
feat(amd): build ethash light cache on GPU

### DIFF
--- a/sources/algo/ethash/opencl/CMakeLists.txt
+++ b/sources/algo/ethash/opencl/CMakeLists.txt
@@ -4,6 +4,7 @@ file(MAKE_DIRECTORY ${OUT_ETHASH})
 
 set(ETHASH_FILES
   ethash_dag.cl
+  ethash_light_cache.cl
   ethash_result.cl
   ethash_search.cl
 )
@@ -20,6 +21,7 @@ endforeach()
 add_custom_target(copy_ethash_opencl_files ALL
   DEPENDS
     ${OUT_ETHASH}/ethash_dag.cl
+    ${OUT_ETHASH}/ethash_light_cache.cl
     ${OUT_ETHASH}/ethash_result.cl
     ${OUT_ETHASH}/ethash_search.cl
 )

--- a/sources/algo/ethash/opencl/ethash_light_cache.cl
+++ b/sources/algo/ethash/opencl/ethash_light_cache.cl
@@ -1,0 +1,58 @@
+#include "kernel/common/rotate_byte.cl"
+#include "kernel/common/xor.cl"
+
+#include "kernel/crypto/keccak_f1600.cl"
+
+
+__kernel
+void ethash_build_light_cache(
+    __global uint4* const restrict cache,
+    uint const cache_number_item)
+{
+    ////////////////////////////////////////////////////////////////////////////
+    // The host wrote the 64 bytes hashed seed into cache[0..3].
+    uint4 item[4];
+    __attribute__((opencl_unroll_hint))
+    for (uint i = 0u; i < 4u; ++i)
+    {
+        item[i] = cache[i];
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    for (uint i = 1u; i < cache_number_item; ++i)
+    {
+        keccak_f1600(item);
+        uint const start_index = i * 4u;
+        __attribute__((opencl_unroll_hint))
+        for (uint j = 0u; j < 4u; ++j)
+        {
+            cache[start_index + j] = item[j];
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    for (uint round = 0u; round < LIGHT_CACHE_ROUNDS; ++round)
+    {
+        for (uint i = 0u; i < cache_number_item; ++i)
+        {
+            uint const start_index = i * 4u;
+            uint const fi = (cache[start_index].x % cache_number_item) * 4u;
+            uint const si = ((cache_number_item + (i - 1u)) % cache_number_item) * 4u;
+
+            uint4 xored[4];
+            __attribute__((opencl_unroll_hint))
+            for (uint j = 0u; j < 4u; ++j)
+            {
+                xored[j] = cache[fi + j] ^ cache[si + j];
+            }
+
+            keccak_f1600(xored);
+
+            __attribute__((opencl_unroll_hint))
+            for (uint j = 0u; j < 4u; ++j)
+            {
+                cache[start_index + j] = xored[j];
+            }
+        }
+    }
+}

--- a/sources/benchmark/amd/ethash_light_cache.cpp
+++ b/sources/benchmark/amd/ethash_light_cache.cpp
@@ -1,0 +1,107 @@
+#if defined(AMD_ENABLE)
+
+#include <CL/opencl.hpp>
+
+#include <algo/ethash/ethash.hpp>
+#include <algo/hash.hpp>
+#include <benchmark/workflow.hpp>
+#include <common/cast.hpp>
+#include <common/custom.hpp>
+#include <common/kernel_generator/opencl.hpp>
+#include <common/opencl/buffer_wrapper.hpp>
+
+
+bool benchmark::BenchmarkWorkflow::runAmdEthashLightCache()
+{
+    ////////////////////////////////////////////////////////////////////////////
+    if (false == config.amd.isAlgoEnabled("ethash_light_cache"))
+    {
+        return true;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    logInfo() << "Running benchmark AMD Light Cache";
+
+    ////////////////////////////////////////////////////////////////////////////
+    common::Dashboard            dashboard{ createNewDashboard("[AMD] Light Cache") };
+    benchmark::AlgoConfig const& algo{ config.amd.getAlgo("ethash_light_cache") };
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Epoch-representative light-cache dimensions, matching the NVIDIA baseline
+    // (1409017 items * 64 bytes = 90177088 bytes). The kernel runs the full
+    // keccak chain and RandMemoHash rounds regardless of the buffer contents,
+    // so an uninitialised buffer measures the same work as a real build.
+    uint32_t const lightCacheNumber{ 1409017u };
+    size_t const   lightCacheSize{ castSize(lightCacheNumber) * algo::LEN_HASH_512 };
+
+    ////////////////////////////////////////////////////////////////////////////
+    common::opencl::Buffer<algo::hash512> lightCache{ CL_MEM_READ_WRITE | CL_MEM_HOST_NO_ACCESS };
+    lightCache.setSize(lightCacheSize);
+    if (false == lightCache.alloc(propertiesAmd.clContext))
+    {
+        logErr() << "Fail to allocate light cache buffer";
+        return false;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    auto benchLightCache = [&](std::string const& kernelName, uint32_t const loop) -> bool
+    {
+        ///////////////////////////////////////////////////////////////////////
+        common::KernelGeneratorOpenCL generator{};
+
+        ///////////////////////////////////////////////////////////////////////
+        generator.setKernelName(kernelName);
+
+        ///////////////////////////////////////////////////////////////////////
+        generator.addDefine("LIGHT_CACHE_ROUNDS", castU32(algo::ethash::LIGHT_CACHE_ROUNDS));
+
+        ///////////////////////////////////////////////////////////////////////
+        generator.appendFile("kernel/ethash_light_cache/" + kernelName + ".cl");
+
+        ///////////////////////////////////////////////////////////////////////
+        if (false == generator.build(&propertiesAmd.clDevice, &propertiesAmd.clContext))
+        {
+            return false;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // Single work-item, single group: the light-cache build is strictly
+        // sequential (keccak chain + i-1 read-after-write) and cannot be split.
+        auto& clKernel{ generator.clKernel };
+        OPENCL_ER(clKernel.setArg(0u, *lightCache.getBuffer()));
+        OPENCL_ER(clKernel.setArg(1u, lightCacheNumber));
+
+        ///////////////////////////////////////////////////////////////////////
+        setGrid(lightCacheNumber, 1u);
+
+        ///////////////////////////////////////////////////////////////////////
+        for (uint32_t i{ 0u }; i < loop; ++i)
+        {
+            startChrono(kernelName);
+            OPENCL_ER(propertiesAmd.clQueue
+                          .enqueueNDRangeKernel(clKernel, cl::NullRange, cl::NDRange(1, 1, 1), cl::NDRange(1, 1, 1)));
+            OPENCL_ER(propertiesAmd.clQueue.finish());
+            stopChrono(dashboard);
+        }
+
+        return true;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    if (true == algo.isKernelEnabled("ethash_light_cache_lm0"))
+    {
+        uint32_t const loop{ algo.resolveKernel("ethash_light_cache_lm0").loop };
+        benchLightCache("ethash_light_cache_lm0", loop);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    lightCache.free();
+
+    ////////////////////////////////////////////////////////////////////////////
+    dashboards.emplace_back(dashboard);
+
+    ////////////////////////////////////////////////////////////////////////////
+    return true;
+}
+
+#endif

--- a/sources/benchmark/config.cpp
+++ b/sources/benchmark/config.cpp
@@ -177,6 +177,7 @@ benchmark::Config benchmark::Config::makeDefault()
 
     cfg.amd.enabled = true;
     cfg.amd.deviceIndex = 0u;
+    cfg.amd.algorithms["ethash_light_cache"] = { true, { 10u, 1u, 1u }, {} };
     cfg.amd.algorithms["kawpow"] = { true, { 1u, 256u, 1024u }, {} };
 
     return cfg;

--- a/sources/benchmark/config.json
+++ b/sources/benchmark/config.json
@@ -70,6 +70,11 @@
         "enabled": false,
         "device_index": 0,
         "algorithms": {
+            "ethash_light_cache": {
+                "enabled": false,
+                "loop": 10,
+                "kernels": ["ethash_light_cache_lm0"]
+            },
             "kawpow": {
                 "enabled": false,
                 "loop": 1,

--- a/sources/benchmark/opencl/CMakeLists.txt
+++ b/sources/benchmark/opencl/CMakeLists.txt
@@ -5,6 +5,7 @@ file(MAKE_DIRECTORY ${OUT_COMMON})
 set(BENCHMARK_OPENCL_FILES
     common/init_array.cl
     common/result.cl
+    ethash_light_cache/ethash_light_cache_lm0.cl
     kawpow/kawpow_lm1.cl
     kawpow/kawpow_lm2.cl
     kawpow/kawpow_lm3.cl
@@ -26,6 +27,7 @@ add_custom_target(copy_benchmark_opencl ALL
     DEPENDS
     ${OUT_COMMON}/common/init_array.cl
     ${OUT_COMMON}/common/result.cl
+    ${OUT_COMMON}/ethash_light_cache/ethash_light_cache_lm0.cl
     ${OUT_COMMON}/kawpow/kawpow_lm1.cl
     ${OUT_COMMON}/kawpow/kawpow_lm2.cl
     ${OUT_COMMON}/kawpow/kawpow_lm3.cl

--- a/sources/benchmark/opencl/ethash_light_cache/ethash_light_cache_lm0.cl
+++ b/sources/benchmark/opencl/ethash_light_cache/ethash_light_cache_lm0.cl
@@ -1,0 +1,58 @@
+#include "kernel/common/rotate_byte.cl"
+#include "kernel/common/xor.cl"
+
+#include "kernel/crypto/keccak_f1600.cl"
+
+
+__kernel
+void ethash_light_cache_lm0(
+    __global uint4* const restrict cache,
+    uint const cache_number_item)
+{
+    ////////////////////////////////////////////////////////////////////////////
+    // The host wrote the 64 bytes hashed seed into cache[0..3].
+    uint4 item[4];
+    __attribute__((opencl_unroll_hint))
+    for (uint i = 0u; i < 4u; ++i)
+    {
+        item[i] = cache[i];
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    for (uint i = 1u; i < cache_number_item; ++i)
+    {
+        keccak_f1600(item);
+        uint const start_index = i * 4u;
+        __attribute__((opencl_unroll_hint))
+        for (uint j = 0u; j < 4u; ++j)
+        {
+            cache[start_index + j] = item[j];
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    for (uint round = 0u; round < LIGHT_CACHE_ROUNDS; ++round)
+    {
+        for (uint i = 0u; i < cache_number_item; ++i)
+        {
+            uint const start_index = i * 4u;
+            uint const fi = (cache[start_index].x % cache_number_item) * 4u;
+            uint const si = ((cache_number_item + (i - 1u)) % cache_number_item) * 4u;
+
+            uint4 xored[4];
+            __attribute__((opencl_unroll_hint))
+            for (uint j = 0u; j < 4u; ++j)
+            {
+                xored[j] = cache[fi + j] ^ cache[si + j];
+            }
+
+            keccak_f1600(xored);
+
+            __attribute__((opencl_unroll_hint))
+            for (uint j = 0u; j < 4u; ++j)
+            {
+                cache[start_index + j] = xored[j];
+            }
+        }
+    }
+}

--- a/sources/benchmark/workflow.cpp
+++ b/sources/benchmark/workflow.cpp
@@ -352,6 +352,10 @@ void benchmark::BenchmarkWorkflow::runAmd()
     currentdeviceType = device::DEVICE_TYPE::AMD;
 
     ///////////////////////////////////////////////////////////////////////////
+    if (false == runAmdEthashLightCache())
+    {
+        logErr() << "AMD ethash light cache failed";
+    }
     if (false == runAmdKawpow())
     {
         logErr() << "AMD kawpow failed";

--- a/sources/benchmark/workflow.hpp
+++ b/sources/benchmark/workflow.hpp
@@ -114,6 +114,7 @@ namespace benchmark
 
 #if defined(AMD_ENABLE)
         void runAmd();
+        bool runAmdEthashLightCache();
         bool runAmdKawpow();
 #endif
     };

--- a/sources/common/opencl/buffer_wrapper.hpp
+++ b/sources/common/opencl/buffer_wrapper.hpp
@@ -33,6 +33,12 @@ namespace common
             }
 
             inline
+            void setFlags(cl_mem_flags const _flags)
+            {
+                flags = _flags;
+            }
+
+            inline
             void setSize(size_t const _size)
             {
                 size = _size;

--- a/sources/resolver/amd/etchash.cpp
+++ b/sources/resolver/amd/etchash.cpp
@@ -20,6 +20,9 @@ resolver::ResolverAmdEtchash::ResolverAmdEtchash() : resolver::ResolverAmdEthash
 bool resolver::ResolverAmdEtchash::updateContext(stratum::StratumJobInfo const& jobInfo)
 {
     ///////////////////////////////////////////////////////////////////////////
+    common::Config const& config{ common::Config::instance() };
+
+    ///////////////////////////////////////////////////////////////////////////
     algo::ethash::ContextGenerator::instance().build(
         algorithm,
         context,
@@ -29,8 +32,7 @@ bool resolver::ResolverAmdEtchash::updateContext(stratum::StratumJobInfo const& 
         dagCountItemsInit,
         lightCacheCountItemsGrowth,
         lightCacheCountItemsInit,
-        true /*config.deviceAlgorithm.ethashBuildLightCacheCPU*/
-    );
+        config.deviceAlgorithm.ethashBuildLightCacheCPU);
 
     if (context.lightCache.numberItem == 0ull || context.lightCache.size == 0ull || context.dagCache.numberItem == 0ull
         || context.dagCache.size == 0ull)

--- a/sources/resolver/amd/ethash.cpp
+++ b/sources/resolver/amd/ethash.cpp
@@ -101,8 +101,9 @@ bool resolver::ResolverAmdEthash::updateMemory(stratum::StratumJobInfo const& jo
     parameters.resultCache.free();
 
     ////////////////////////////////////////////////////////////////////////////
-    parameters.lightCache.setFlags(true == buildLightCacheOnCPU ? CL_MEM_READ_ONLY | CL_MEM_HOST_WRITE_ONLY
-                                                                : CL_MEM_READ_WRITE | CL_MEM_HOST_WRITE_ONLY);
+    parameters.lightCache.setFlags(
+        true == buildLightCacheOnCPU ? CL_MEM_READ_ONLY | CL_MEM_HOST_WRITE_ONLY
+                                     : CL_MEM_READ_WRITE | CL_MEM_HOST_WRITE_ONLY);
     parameters.lightCache.setSize(context.lightCache.size);
     parameters.dagCache.setSize(context.dagCache.size);
 
@@ -118,8 +119,8 @@ bool resolver::ResolverAmdEthash::updateMemory(stratum::StratumJobInfo const& jo
     if (true == buildLightCacheOnCPU)
     {
         if (false
-            == parameters.lightCache.write(
-                context.lightCache.hash, context.lightCache.size, clQueue[currentIndexStream]))
+            == parameters.lightCache
+                   .write(context.lightCache.hash, context.lightCache.size, clQueue[currentIndexStream]))
         {
             return false;
         }
@@ -208,11 +209,8 @@ bool resolver::ResolverAmdEthash::buildLightCache()
     resolverInfo() << "Building light cache on GPU";
     common::Chrono chrono{};
     chrono.start();
-    OPENCL_ER(clQueue[currentIndexStream]->enqueueNDRangeKernel(
-        clKernel,
-        cl::NullRange,
-        cl::NDRange(1, 1, 1),
-        cl::NDRange(1, 1, 1)));
+    OPENCL_ER(clQueue[currentIndexStream]
+                  ->enqueueNDRangeKernel(clKernel, cl::NullRange, cl::NDRange(1, 1, 1), cl::NDRange(1, 1, 1)));
     OPENCL_ER(clQueue[currentIndexStream]->finish());
     chrono.stop();
     resolverInfo() << "Built light cache on GPU in " << chrono.elapsed(common::CHRONO_UNIT::MS) << "ms";

--- a/sources/resolver/amd/ethash.cpp
+++ b/sources/resolver/amd/ethash.cpp
@@ -32,6 +32,9 @@ resolver::ResolverAmdEthash::~ResolverAmdEthash()
 bool resolver::ResolverAmdEthash::updateContext(stratum::StratumJobInfo const& jobInfo)
 {
     ///////////////////////////////////////////////////////////////////////////
+    common::Config const& config{ common::Config::instance() };
+
+    ///////////////////////////////////////////////////////////////////////////
     algo::ethash::ContextGenerator::instance().build(
         algorithm,
         context,
@@ -41,8 +44,7 @@ bool resolver::ResolverAmdEthash::updateContext(stratum::StratumJobInfo const& j
         dagCountItemsInit,
         lightCacheCountItemsGrowth,
         lightCacheCountItemsInit,
-        true /*config.deviceAlgorithm.ethashBuildLightCacheCPU*/
-    );
+        config.deviceAlgorithm.ethashBuildLightCacheCPU);
 
     if (context.lightCache.numberItem == 0ull || context.lightCache.size == 0ull || context.dagCache.numberItem == 0ull
         || context.dagCache.size == 0ull)
@@ -89,12 +91,18 @@ bool resolver::ResolverAmdEthash::updateMemory(stratum::StratumJobInfo const& jo
     }
 
     ////////////////////////////////////////////////////////////////////////////
+    common::Config const& config{ common::Config::instance() };
+    bool const            buildLightCacheOnCPU{ config.deviceAlgorithm.ethashBuildLightCacheCPU };
+
+    ////////////////////////////////////////////////////////////////////////////
     parameters.lightCache.free();
     parameters.dagCache.free();
     parameters.headerCache.free();
     parameters.resultCache.free();
 
     ////////////////////////////////////////////////////////////////////////////
+    parameters.lightCache.setFlags(true == buildLightCacheOnCPU ? CL_MEM_READ_ONLY | CL_MEM_HOST_WRITE_ONLY
+                                                                : CL_MEM_READ_WRITE | CL_MEM_HOST_WRITE_ONLY);
     parameters.lightCache.setSize(context.lightCache.size);
     parameters.dagCache.setSize(context.dagCache.size);
 
@@ -107,10 +115,26 @@ bool resolver::ResolverAmdEthash::updateMemory(stratum::StratumJobInfo const& jo
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    if (false
-        == parameters.lightCache.write(context.lightCache.hash, context.lightCache.size, clQueue[currentIndexStream]))
+    if (true == buildLightCacheOnCPU)
     {
-        return false;
+        if (false
+            == parameters.lightCache.write(
+                context.lightCache.hash, context.lightCache.size, clQueue[currentIndexStream]))
+        {
+            return false;
+        }
+    }
+    else
+    {
+        if (false
+            == parameters.lightCache.write(&context.hashedSeedCache, algo::LEN_HASH_512, clQueue[currentIndexStream]))
+        {
+            return false;
+        }
+        if (false == buildLightCache())
+        {
+            return false;
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -139,6 +163,59 @@ bool resolver::ResolverAmdEthash::updateConstants(stratum::StratumJobInfo const&
     ////////////////////////////////////////////////////////////////////////////
     overrideOccupancy(8192u, getMaxGroupSize());
 
+
+    ////////////////////////////////////////////////////////////////////////////
+    return true;
+}
+
+
+bool resolver::ResolverAmdEthash::buildLightCache()
+{
+    ////////////////////////////////////////////////////////////////////////////
+    // Clear old data
+    kernelGenerator.clear();
+
+    ////////////////////////////////////////////////////////////////////////////
+    // kernel name
+    kernelGenerator.setKernelName("ethash_build_light_cache");
+
+    ////////////////////////////////////////////////////////////////////////////
+    // defines
+    kernelGenerator.addDefine("LIGHT_CACHE_ROUNDS", castU32(algo::ethash::LIGHT_CACHE_ROUNDS));
+
+    ////////////////////////////////////////////////////////////////////////////
+    // ethash files
+    if (false == kernelGenerator.appendFile("kernel/ethash/ethash_light_cache.cl"))
+    {
+        return false;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // build opencl kernel
+    if (false == kernelGenerator.build(clDevice, clContext))
+    {
+        return false;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Set kernel parameters
+    auto& clKernel{ kernelGenerator.clKernel };
+    OPENCL_ER(clKernel.setArg(0u, *(parameters.lightCache.getBuffer())));
+    OPENCL_ER(clKernel.setArg(1u, castU32(context.lightCache.numberItem)));
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Run kernel to build light cache
+    resolverInfo() << "Building light cache on GPU";
+    common::Chrono chrono{};
+    chrono.start();
+    OPENCL_ER(clQueue[currentIndexStream]->enqueueNDRangeKernel(
+        clKernel,
+        cl::NullRange,
+        cl::NDRange(1, 1, 1),
+        cl::NDRange(1, 1, 1)));
+    OPENCL_ER(clQueue[currentIndexStream]->finish());
+    chrono.stop();
+    resolverInfo() << "Built light cache on GPU in " << chrono.elapsed(common::CHRONO_UNIT::MS) << "ms";
 
     ////////////////////////////////////////////////////////////////////////////
     return true;

--- a/sources/resolver/amd/ethash.hpp
+++ b/sources/resolver/amd/ethash.hpp
@@ -39,6 +39,7 @@ namespace resolver
 
         virtual bool updateContext(stratum::StratumJobInfo const& jobInfo);
 
+        bool buildLightCache();
         bool buildDAG();
         bool buildSearch();
         bool getResultCache(std::string const& _jobId, uint32_t const extraNonceSize);

--- a/sources/resolver/amd/progpow.cpp
+++ b/sources/resolver/amd/progpow.cpp
@@ -93,8 +93,9 @@ bool resolver::ResolverAmdProgPOW::updateMemory(stratum::StratumJobInfo const& j
     parameters.lightCache.free();
 
     ////////////////////////////////////////////////////////////////////////////
-    parameters.lightCache.setFlags(true == buildLightCacheOnCPU ? CL_MEM_READ_ONLY | CL_MEM_HOST_WRITE_ONLY
-                                                                : CL_MEM_READ_WRITE | CL_MEM_HOST_WRITE_ONLY);
+    parameters.lightCache.setFlags(
+        true == buildLightCacheOnCPU ? CL_MEM_READ_ONLY | CL_MEM_HOST_WRITE_ONLY
+                                     : CL_MEM_READ_WRITE | CL_MEM_HOST_WRITE_ONLY);
     parameters.lightCache.setSize(context.lightCache.size);
     parameters.dagCache.setSize(context.dagCache.size);
 
@@ -110,8 +111,8 @@ bool resolver::ResolverAmdProgPOW::updateMemory(stratum::StratumJobInfo const& j
     if (true == buildLightCacheOnCPU)
     {
         if (false
-            == parameters.lightCache.write(
-                context.lightCache.hash, context.lightCache.size, clQueue[currentIndexStream]))
+            == parameters.lightCache
+                   .write(context.lightCache.hash, context.lightCache.size, clQueue[currentIndexStream]))
         {
             return false;
         }
@@ -211,11 +212,8 @@ bool resolver::ResolverAmdProgPOW::buildLightCache()
     resolverInfo() << "Building light cache on GPU";
     common::Chrono chrono{};
     chrono.start();
-    OPENCL_ER(clQueue[currentIndexStream]->enqueueNDRangeKernel(
-        clKernel,
-        cl::NullRange,
-        cl::NDRange(1, 1, 1),
-        cl::NDRange(1, 1, 1)));
+    OPENCL_ER(clQueue[currentIndexStream]
+                  ->enqueueNDRangeKernel(clKernel, cl::NullRange, cl::NDRange(1, 1, 1), cl::NDRange(1, 1, 1)));
     OPENCL_ER(clQueue[currentIndexStream]->finish());
     chrono.stop();
     resolverInfo() << "Built light cache on GPU in " << chrono.elapsed(common::CHRONO_UNIT::MS) << "ms";

--- a/sources/resolver/amd/progpow.cpp
+++ b/sources/resolver/amd/progpow.cpp
@@ -1,6 +1,7 @@
 #include <algo/ethash/ethash.hpp>
 #include <algo/hash_utils.hpp>
 #include <common/cast.hpp>
+#include <common/chrono.hpp>
 #include <common/config.hpp>
 #include <common/custom.hpp>
 #include <common/error/opencl_error.hpp>
@@ -29,6 +30,9 @@ resolver::ResolverAmdProgPOW::~ResolverAmdProgPOW()
 bool resolver::ResolverAmdProgPOW::updateContext(stratum::StratumJobInfo const& jobInfo)
 {
     ///////////////////////////////////////////////////////////////////////////
+    common::Config const& config{ common::Config::instance() };
+
+    ///////////////////////////////////////////////////////////////////////////
     algo::ethash::ContextGenerator::instance().build(
         algorithm,
         context,
@@ -38,8 +42,7 @@ bool resolver::ResolverAmdProgPOW::updateContext(stratum::StratumJobInfo const& 
         dagCountItemsInit,
         lightCacheCountItemsGrowth,
         lightCacheCountItemsInit,
-        true /*config.deviceAlgorithm.ethashBuildLightCacheCPU*/
-    );
+        config.deviceAlgorithm.ethashBuildLightCacheCPU);
 
     if (0ull == context.lightCache.numberItem || 0ull == context.lightCache.size || 0ull == context.dagCache.numberItem
         || 0ull == context.dagCache.size)
@@ -80,12 +83,18 @@ bool resolver::ResolverAmdProgPOW::updateMemory(stratum::StratumJobInfo const& j
     }
 
     ////////////////////////////////////////////////////////////////////////////
+    common::Config const& config{ common::Config::instance() };
+    bool const            buildLightCacheOnCPU{ config.deviceAlgorithm.ethashBuildLightCacheCPU };
+
+    ////////////////////////////////////////////////////////////////////////////
     parameters.headerCache.free();
     parameters.resultCache.free();
     parameters.dagCache.free();
     parameters.lightCache.free();
 
     ////////////////////////////////////////////////////////////////////////////
+    parameters.lightCache.setFlags(true == buildLightCacheOnCPU ? CL_MEM_READ_ONLY | CL_MEM_HOST_WRITE_ONLY
+                                                                : CL_MEM_READ_WRITE | CL_MEM_HOST_WRITE_ONLY);
     parameters.lightCache.setSize(context.lightCache.size);
     parameters.dagCache.setSize(context.dagCache.size);
 
@@ -98,10 +107,26 @@ bool resolver::ResolverAmdProgPOW::updateMemory(stratum::StratumJobInfo const& j
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    if (false
-        == parameters.lightCache.write(context.lightCache.hash, context.lightCache.size, clQueue[currentIndexStream]))
+    if (true == buildLightCacheOnCPU)
     {
-        return false;
+        if (false
+            == parameters.lightCache.write(
+                context.lightCache.hash, context.lightCache.size, clQueue[currentIndexStream]))
+        {
+            return false;
+        }
+    }
+    else
+    {
+        if (false
+            == parameters.lightCache.write(&context.hashedSeedCache, algo::LEN_HASH_512, clQueue[currentIndexStream]))
+        {
+            return false;
+        }
+        if (false == buildLightCache())
+        {
+            return false;
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -141,6 +166,59 @@ bool resolver::ResolverAmdProgPOW::updateConstants(stratum::StratumJobInfo const
     {
         return false;
     }
+
+    ////////////////////////////////////////////////////////////////////////////
+    return true;
+}
+
+
+bool resolver::ResolverAmdProgPOW::buildLightCache()
+{
+    ////////////////////////////////////////////////////////////////////////////
+    // Clear old data
+    kernelGenerator.clear();
+
+    ////////////////////////////////////////////////////////////////////////////
+    // kernel name
+    kernelGenerator.setKernelName("ethash_build_light_cache");
+
+    ////////////////////////////////////////////////////////////////////////////
+    // defines
+    kernelGenerator.addDefine("LIGHT_CACHE_ROUNDS", castU32(algo::ethash::LIGHT_CACHE_ROUNDS));
+
+    ////////////////////////////////////////////////////////////////////////////
+    // ethash files
+    if (false == kernelGenerator.appendFile("kernel/ethash/ethash_light_cache.cl"))
+    {
+        return false;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // build opencl kernel
+    if (false == kernelGenerator.build(clDevice, clContext))
+    {
+        return false;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Set kernel parameters
+    auto& clKernel{ kernelGenerator.clKernel };
+    OPENCL_ER(clKernel.setArg(0u, *(parameters.lightCache.getBuffer())));
+    OPENCL_ER(clKernel.setArg(1u, castU32(context.lightCache.numberItem)));
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Run kernel to build light cache
+    resolverInfo() << "Building light cache on GPU";
+    common::Chrono chrono{};
+    chrono.start();
+    OPENCL_ER(clQueue[currentIndexStream]->enqueueNDRangeKernel(
+        clKernel,
+        cl::NullRange,
+        cl::NDRange(1, 1, 1),
+        cl::NDRange(1, 1, 1)));
+    OPENCL_ER(clQueue[currentIndexStream]->finish());
+    chrono.stop();
+    resolverInfo() << "Built light cache on GPU in " << chrono.elapsed(common::CHRONO_UNIT::MS) << "ms";
 
     ////////////////////////////////////////////////////////////////////////////
     return true;

--- a/sources/resolver/amd/progpow.hpp
+++ b/sources/resolver/amd/progpow.hpp
@@ -48,6 +48,7 @@ namespace resolver
 
         virtual bool updateContext(stratum::StratumJobInfo const& jobInfo);
 
+        bool buildLightCache();
         bool buildDAG();
         bool buildSearch();
         bool getResultCache(std::string const& jobId, uint32_t const extraNonceSize);

--- a/sources/resolver/amd/tests/ethash.cpp
+++ b/sources/resolver/amd/tests/ethash.cpp
@@ -4,6 +4,7 @@
 #include <algo/ethash/ethash.hpp>
 #include <algo/hash.hpp>
 #include <algo/hash_utils.hpp>
+#include <common/config.hpp>
 #include <common/log/log.hpp>
 #include <common/mocker/stratum.hpp>
 #include <resolver/amd/ethash.hpp>
@@ -19,6 +20,11 @@ struct ResolverEthashAmdTest : public testing::Test
 
     ResolverEthashAmdTest()
     {
+        ////////////////////////////////////////////////////////////////////////////
+        common::Config& config{ common::Config::instance() };
+        config.deviceAlgorithm.ethashBuildLightCacheCPU = true;
+
+        ////////////////////////////////////////////////////////////////////////////
         common::setLogLevel(common::TYPELOG::__DEBUG);
 
         if (false == resolver::tests::initializeOpenCL(properties))
@@ -59,6 +65,29 @@ TEST_F(ResolverEthashAmdTest, emptyJob)
 
 TEST_F(ResolverEthashAmdTest, findNonce)
 {
+    initializeJob(0x77530000094A7C09);
+
+    ASSERT_TRUE(resolver.updateMemory(jobInfo));
+    ASSERT_TRUE(resolver.updateConstants(jobInfo));
+    ASSERT_TRUE(resolver.executeSync(jobInfo));
+    resolver.submit(&stratum);
+
+    ASSERT_FALSE(stratum.paramSubmit.empty());
+
+    std::string const nonceStr{ stratum.paramSubmit[1].as_string().c_str() };
+
+    using namespace std::string_literals;
+    EXPECT_EQ("77530000094a7c09"s, nonceStr);
+}
+
+
+TEST_F(ResolverEthashAmdTest, findNonceWithLightCacheGPU)
+{
+    ////////////////////////////////////////////////////////////////////////////
+    common::Config& config{ common::Config::instance() };
+    config.deviceAlgorithm.ethashBuildLightCacheCPU = false;
+
+    ////////////////////////////////////////////////////////////////////////////
     initializeJob(0x77530000094A7C09);
 
     ASSERT_TRUE(resolver.updateMemory(jobInfo));

--- a/sources/resolver/amd/tests/firopow.cpp
+++ b/sources/resolver/amd/tests/firopow.cpp
@@ -4,6 +4,7 @@
 #include <algo/hash.hpp>
 #include <algo/hash_utils.hpp>
 #include <algo/progpow/firopow.hpp>
+#include <common/config.hpp>
 #include <common/log/log.hpp>
 #include <common/mocker/stratum.hpp>
 #include <resolver/amd/firopow.hpp>
@@ -19,6 +20,11 @@ struct ResolverFiropowAmdTest : public testing::Test
 
     ResolverFiropowAmdTest()
     {
+        ////////////////////////////////////////////////////////////////////////////
+        common::Config& config{ common::Config::instance() };
+        config.deviceAlgorithm.ethashBuildLightCacheCPU = true;
+
+        ////////////////////////////////////////////////////////////////////////////
         common::setLogLevel(common::TYPELOG::__DEBUG);
 
         if (false == resolver::tests::initializeOpenCL(properties))

--- a/sources/resolver/amd/tests/kawpow.cpp
+++ b/sources/resolver/amd/tests/kawpow.cpp
@@ -4,6 +4,7 @@
 #include <algo/hash.hpp>
 #include <algo/hash_utils.hpp>
 #include <algo/progpow/kawpow.hpp>
+#include <common/config.hpp>
 #include <common/log/log.hpp>
 #include <common/mocker/stratum.hpp>
 #include <resolver/amd/kawpow.hpp>
@@ -19,6 +20,11 @@ struct ResolverKawpowAmdTest : public testing::Test
 
     ResolverKawpowAmdTest()
     {
+        ////////////////////////////////////////////////////////////////////////////
+        common::Config& config{ common::Config::instance() };
+        config.deviceAlgorithm.ethashBuildLightCacheCPU = true;
+
+        ////////////////////////////////////////////////////////////////////////////
         common::setLogLevel(common::TYPELOG::__DEBUG);
     }
 
@@ -58,6 +64,30 @@ struct ResolverKawpowAmdTest : public testing::Test
 
 TEST_F(ResolverKawpowAmdTest, findNonce)
 {
+    initializeDevice(0u);
+    initializeJob(0xce00000017f87f70);
+
+    ASSERT_TRUE(resolver.updateMemory(jobInfo));
+    ASSERT_TRUE(resolver.updateConstants(jobInfo));
+    ASSERT_TRUE(resolver.executeSync(jobInfo));
+    resolver.submit(&stratum);
+
+    ASSERT_FALSE(stratum.paramSubmit.empty());
+
+    std::string const nonceStr{ stratum.paramSubmit[1].as_string().c_str() };
+
+    using namespace std::string_literals;
+    EXPECT_EQ("0xce00000017f87f7a"s, nonceStr);
+}
+
+
+TEST_F(ResolverKawpowAmdTest, findNonceWithLightCacheGPU)
+{
+    ////////////////////////////////////////////////////////////////////////////
+    common::Config& config{ common::Config::instance() };
+    config.deviceAlgorithm.ethashBuildLightCacheCPU = false;
+
+    ////////////////////////////////////////////////////////////////////////////
     initializeDevice(0u);
     initializeJob(0xce00000017f87f70);
 

--- a/sources/resolver/amd/tests/meowpow.cpp
+++ b/sources/resolver/amd/tests/meowpow.cpp
@@ -4,6 +4,7 @@
 #include <algo/hash.hpp>
 #include <algo/hash_utils.hpp>
 #include <algo/progpow/meowpow.hpp>
+#include <common/config.hpp>
 #include <common/log/log.hpp>
 #include <common/mocker/stratum.hpp>
 #include <resolver/amd/meowpow.hpp>
@@ -19,6 +20,11 @@ struct ResolverMeowpowAmdTest : public testing::Test
 
     ResolverMeowpowAmdTest()
     {
+        ////////////////////////////////////////////////////////////////////////////
+        common::Config& config{ common::Config::instance() };
+        config.deviceAlgorithm.ethashBuildLightCacheCPU = true;
+
+        ////////////////////////////////////////////////////////////////////////////
         common::setLogLevel(common::TYPELOG::__DEBUG);
     }
 

--- a/sources/resolver/amd/tests/progpow_quai.cpp
+++ b/sources/resolver/amd/tests/progpow_quai.cpp
@@ -4,6 +4,7 @@
 #include <algo/hash.hpp>
 #include <algo/hash_utils.hpp>
 #include <algo/progpow/progpow_quai.hpp>
+#include <common/config.hpp>
 #include <common/log/log.hpp>
 #include <common/mocker/stratum.hpp>
 #include <resolver/amd/progpow_quai.hpp>
@@ -19,6 +20,11 @@ struct ResolverProgpowQuaiAmdTest : public testing::Test
 
     ResolverProgpowQuaiAmdTest()
     {
+        ////////////////////////////////////////////////////////////////////////////
+        common::Config& config{ common::Config::instance() };
+        config.deviceAlgorithm.ethashBuildLightCacheCPU = true;
+
+        ////////////////////////////////////////////////////////////////////////////
         common::setLogLevel(common::TYPELOG::__DEBUG);
     }
 

--- a/sources/resolver/amd/tests/progpow_z.cpp
+++ b/sources/resolver/amd/tests/progpow_z.cpp
@@ -4,6 +4,7 @@
 #include <algo/hash.hpp>
 #include <algo/hash_utils.hpp>
 #include <algo/progpow/progpow.hpp>
+#include <common/config.hpp>
 #include <common/log/log.hpp>
 #include <common/mocker/stratum.hpp>
 #include <resolver/amd/progpow.hpp>
@@ -19,6 +20,11 @@ struct ResolverProgpowZAmdTest : public testing::Test
 
     ResolverProgpowZAmdTest()
     {
+        ////////////////////////////////////////////////////////////////////////////
+        common::Config& config{ common::Config::instance() };
+        config.deviceAlgorithm.ethashBuildLightCacheCPU = true;
+
+        ////////////////////////////////////////////////////////////////////////////
         common::setLogLevel(common::TYPELOG::__DEBUG);
     }
 


### PR DESCRIPTION
Implements #104.

## Summary

The AMD/OpenCL resolvers now honor `--ethash_light_cache_cpu` (default `true`) instead of hardcoding CPU light-cache generation. With `--ethash_light_cache_cpu=false`, only the 64-byte hashed seed is uploaded and the light cache is generated on-device, mirroring the existing NVIDIA CUDA path (`ethashBuildLightCache`).

Covers the whole ethash family — ethash, etchash, and all progpow variants (kawpow, meowpow, firopow, evrprogpow, progpow-quai, progpow-z) — via the shared `ResolverAmdEthash` / `ResolverAmdProgPOW` base classes.

## Changes

- **New kernel** `sources/algo/ethash/opencl/ethash_light_cache.cl` — single work-item. The light-cache build is strictly sequential (an iterated keccak-512 chain followed by 3 RandMemoHash rounds with an `i-1` read-after-write), so it cannot be parallelised — same as the CUDA `<<<1,1>>>` path. Reuses the existing `keccak_f1600`.
- **`common::opencl::Buffer::setFlags()`** — lets the light-cache buffer switch to `CL_MEM_READ_WRITE` when the kernel writes it (it is `CL_MEM_READ_ONLY` on the CPU-upload path).
- **Resolvers** — `updateContext()` reads the config flag; `updateMemory()` branches: CPU mode writes the full host cache (unchanged), GPU mode writes the 64-byte seed then runs `buildLightCache()`.
- **Tests** — `findNonceWithLightCacheGPU` for the AMD ethash and kawpow suites, mirroring the NVIDIA tests; ethash-family AMD fixtures pin `ethashBuildLightCacheCPU` for determinism.

## Why (it is not a speed feature)

The light-cache build is sequential by design, so on a single GPU it is ~9–10x slower than a CPU core — CPU build stays the default. The value is: no ~50–100 MB PCIe upload (just 64 bytes), no host-CPU load, and each GPU builds its own cache concurrently — useful on many-GPU rigs with a weak/contended CPU. This is the AMD counterpart of the option NVIDIA already exposes.

## Verification (RX 9070 XT, gfx1201)

- **Unit:** kawpow `findNonceWithLightCacheGPU` finds the exact expected nonce — end-to-end bit-exactness, since the progpow hash depends on the entire DAG, which depends on the entire light cache.
- **Live pool:** kawpow on `rvn.2miners.com` with `--ethash_light_cache_cpu=false` → log `Built light cache on GPU` → **Share valid (1 valid / 0 reject)**.

## Note on ethash + RDNA4

On RDNA4, plain **ethash** currently fails to produce valid shares regardless of CPU vs GPU light cache, due to a pre-existing DAG-build coverage bug (`ethash_build_dag` under-dispatches work-groups on gfx1201). That is independent of this PR — the CPU light-cache path is equally affected — and is handled separately. With that fix applied, the full ethash + kawpow GPU-light-cache test matrix is green on hardware. kawpow/progpow are unaffected and verified live as above.
