### PR TITLE
fix(device): report hashrate under fast job streams

### DIFF
--- a/sources/device/device.cpp
+++ b/sources/device/device.cpp
@@ -623,9 +623,18 @@ void device::Device::updateBatchNonce()
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    miningStats.setBatchNonce(resolver->getBlocks() * resolver->getThreads() * internalLoop);
-    miningStats.resetHashrate();
-    miningStats.reset();
+    // updateJob() calls this on every job. Only reset the hashrate accumulator when the
+    // batch size actually changes (an occupancy change — rare), never per job: otherwise a
+    // slow kernel under a fast job stream (e.g. XelisHash V3, ~1 job/s) never reaches
+    // kernelMinimunExecuteNeeded before the counter is zeroed, so the hashrate stays 0.
+    uint64_t const newBatchNonce{ static_cast<uint64_t>(resolver->getBlocks()) * resolver->getThreads()
+                                  * internalLoop };
+    if (newBatchNonce != miningStats.getBatchNonce())
+    {
+        miningStats.setBatchNonce(newBatchNonce);
+        miningStats.resetHashrate();
+        miningStats.reset();
+    }
 }
 
 


### PR DESCRIPTION
## Problem

`Device::updateBatchNonce()` is called by `updateJob()` on **every** pool job and unconditionally reset the hashrate accumulator (`resetHashrate()` + `reset()`).

`Device::getHashrate()` only publishes a measurement once `kernelExecuted >= occupancy.kernelMinimunExecuteNeeded` (default **100**). For a slow kernel under a fast job stream — e.g. a memory-hard algorithm at ~1.7 s/launch against a pool pushing ~1 job/s — only a handful of kernels run per job, so `kernelExecuted` is zeroed long before it ever reaches the threshold. Result: the reported hashrate stays pinned at **0** even though the GPU is mining and submitting accepted shares.

## Fix

Only reset the accumulator when the batch size *actually changes* (an occupancy change — rare), instead of on every job:

```cpp
uint64_t const newBatchNonce{ static_cast<uint64_t>(resolver->getBlocks()) * resolver->getThreads()
                              * internalLoop };
if (newBatchNonce != miningStats.getBatchNonce())
{
    miningStats.setBatchNonce(newBatchNonce);
    miningStats.resetHashrate();
    miningStats.reset();
}
```

- `batchNonce` is still recomputed and stored every job, so there is **no nonce-stride regression**.
- The execution counter now accumulates across jobs into a smoother measurement window — strictly better for all algorithms, and a hard requirement for slow/memory-hard ones.

## Testing

Verified on an RX 9070 XT against a live pool: reported hashrate now matches the share-math baseline (was `0` before the fix), with no change in accepted/rejected share behaviour.
