### PR TITLE
fix(docker): windows-cross copies binaries from repo-root bin/

### DIFF
--- a/docker/Dockerfile.windows-cross
+++ b/docker/Dockerfile.windows-cross
@@ -190,8 +190,8 @@ RUN --mount=type=cache,target=/root/.cache/vcpkg \
 # Ship runtime DLLs next to miner.exe (separate RUN so a build failure above is
 # never masked). OpenSSL always; CUDA DLLs only exist when NVIDIA was staged.
 RUN set -eux; \
-    cp /opt/openssl-win/bin/*.dll /src/build/windows-cross/bin/; \
-    if [ "$GPU" != "amd" ]; then cp /opt/cuda-win/bin/*.dll /src/build/windows-cross/bin/; fi
+    cp /opt/openssl-win/bin/*.dll /src/bin/; \
+    if [ "$GPU" != "amd" ]; then cp /opt/cuda-win/bin/*.dll /src/bin/; fi
 
 FROM scratch AS artifact
-COPY --from=build /src/build/windows-cross/bin /
+COPY --from=build /src/bin /


### PR DESCRIPTION
## Summary

`CMAKE_RUNTIME_OUTPUT_DIRECTORY` was moved to the repo-root `bin/` (`/src/bin`) for every preset, but `docker/Dockerfile.windows-cross` still references the old `/src/build/windows-cross/bin`:

- it stages the OpenSSL/CUDA runtime DLLs into `/src/build/windows-cross/bin/`, and
- the `artifact` stage copies from `/src/build/windows-cross/bin`.

That directory no longer exists after the build (binaries now land in `/src/bin`), so the DLL-copy `RUN` fails and the artifact build is broken. This points both at `/src/bin`.

## Test plan

- [x] `docker buildx build --check` passes.
- [x] `docker build -f docker/Dockerfile.windows-cross --build-arg GPU=both --target artifact -o dist/windows-cross-both .` produces `miner.exe` + OpenSSL/CUDA DLLs (verified locally — full cross-build run; see comment below for the build log lines and artifact listing).
