### PR TITLE
ci: fix AMD Linux build, gate docs-only runs, and speed up CUDA CI

### DIFF
--- a/.github/workflows/miner_linux.yml
+++ b/.github/workflows/miner_linux.yml
@@ -4,11 +4,42 @@ on:
   pull_request:
     branches:
       - main
+    # Docs-only changes don't affect the build: skip the ~45-min miner matrix.
+    paths-ignore:
+      - '**.md'
+      - 'documentation/**'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'documentation/**'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   workflow_dispatch:
+    inputs:
+      full_build:
+        description: "Full build: all 3 backends (AMD/NVIDIA/ALL) with the complete multi-arch CUDA fat binary. Off (default) = single ALL build at one CUDA arch (fast CI validation)."
+        required: false
+        type: boolean
+        default: false
   workflow_call:
+    inputs:
+      full_build:
+        description: "Full release build (3 backends, all CUDA archs)."
+        required: false
+        type: boolean
+        default: false
+
+# Supersede stale in-progress runs for the same PR; push-to-main and release
+# (workflow_call, event_name != pull_request) runs always complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # ============================================================
@@ -37,6 +68,8 @@ jobs:
   # Build Miner AMD
   #==========================================================================
   build-miner-amd:
+    # Per-backend artifact only needed for releases; PR/push validate via build-miner-all.
+    if: ${{ inputs.full_build }}
     needs: [build-cmake, build-boost, build-openssl, build-opencl]
     runs-on: ubuntu-22.04
 
@@ -128,6 +161,8 @@ jobs:
           cd build
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=clang-15 \
+            -DCMAKE_CXX_COMPILER=clang++-15 \
             -DBUILD_EXE_BENCHMARK=OFF \
             -DBUILD_EXE_UNIT_TEST=OFF \
             -DBUILD_EXE_MINER=ON \
@@ -153,6 +188,8 @@ jobs:
   # Build Miner NVIDIA
   #==========================================================================
   build-miner-nvidia:
+    # Per-backend artifact only needed for releases; PR/push validate via build-miner-all.
+    if: ${{ inputs.full_build }}
     needs: [build-cmake, build-boost, build-openssl, build-opencl, build-cuda]
     runs-on: ubuntu-22.04
 
@@ -259,6 +296,8 @@ jobs:
           cd build
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=clang-15 \
+            -DCMAKE_CXX_COMPILER=clang++-15 \
             -DBUILD_EXE_BENCHMARK=OFF \
             -DBUILD_EXE_UNIT_TEST=OFF \
             -DBUILD_EXE_MINER=ON \
@@ -297,6 +336,8 @@ jobs:
 
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      # Empty on PR/push -> single CUDA arch (fast); "true" on release -> full fat binary.
+      FULL_BUILD: ${{ inputs.full_build }}
 
     steps:
       - uses: actions/checkout@v4
@@ -394,10 +435,17 @@ jobs:
       # ===============================
       - name: Configure CMake (ALL)
         run: |
+          # Runners have no GPU: a single CUDA arch is enough to validate that the
+          # code compiles. Release builds (full_build) omit this for the full fat binary.
+          ARCH_FLAG=""
+          if [ "$FULL_BUILD" != "true" ]; then ARCH_FLAG="-DNVCC_ARCH_COMPUTE=89"; fi
           mkdir build
           cd build
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
+            $ARCH_FLAG \
+            -DCMAKE_C_COMPILER=clang-15 \
+            -DCMAKE_CXX_COMPILER=clang++-15 \
             -DBUILD_EXE_BENCHMARK=OFF \
             -DBUILD_EXE_UNIT_TEST=OFF \
             -DBUILD_EXE_MINER=ON \

--- a/.github/workflows/miner_release.yml
+++ b/.github/workflows/miner_release.yml
@@ -14,6 +14,8 @@ jobs:
   # ============================================================
   build:
     uses: ./.github/workflows/miner_linux.yml
+    with:
+      full_build: true
 
   # ============================================================
   # Create the GitHub draft release with the 3 binaries

--- a/.github/workflows/unit_test_linux.yml
+++ b/.github/workflows/unit_test_linux.yml
@@ -4,7 +4,19 @@ on:
   pull_request:
     branches:
       - main
+    # Docs-only changes can't break the tests: skip the build+test run.
+    paths-ignore:
+      - '**.md'
+      - 'documentation/**'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
   workflow_dispatch:
+
+# Supersede stale in-progress runs for the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-cmake:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,9 @@ elseif (BUILD_NVIDIA)
     list(APPEND CUDA_NVCC_FLAGS "--ptxas-options=-v")
     list(APPEND CUDA_NVCC_FLAGS "-use_fast_math")
     list(APPEND CUDA_NVCC_FLAGS "-Xptxas -v")
+    # Parallelize per-arch device codegen across CPU threads; speeds the multi-arch
+    # release fat-binary build and is a no-op for single-arch CI builds.
+    list(APPEND CUDA_NVCC_FLAGS "-t0")
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         list(APPEND CUDA_NVCC_FLAGS_DEBUG -G -g -O0)
     else()


### PR DESCRIPTION
## Summary

Fixes the failing **Linux Miner** AMD build, stops CI from running on docs-only changes, cancels superseded PR runs, and cuts the CUDA compile time of CI builds. No source/runtime behavior changes — workflow + one CMake build-flag only.

## Root cause of the AMD build failure

The `build-miner-amd` / `build-miner-nvidia` / `build-miner-all` jobs did **not** pin the compiler on the `cmake` command line. `CMakeLists.txt` force-sets `CMAKE_C_COMPILER=clang-15` *after* `project()` has already detected gcc:

```
You have changed variables that require your cache to be deleted.
Configure will be re-run ...
The following variables have changed: CMAKE_C_COMPILER= clang-15
```

That cache wipe + re-run drops the command-line `-DBUILD_NVIDIA=OFF`, so `option(BUILD_NVIDIA ... ON)` reverts to its default. The AMD-only build then runs the CUDA `find_library()` at `CMakeLists.txt:502` on a runner with no CUDA and fails at configure. The `unit_test` job never hit this because it already passes `-DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15` up front.

## Changes

**AMD build fix**
- Pin `-DCMAKE_C_COMPILER=clang-15 -DCMAKE_CXX_COMPILER=clang++-15` in all three miner configure steps (matching the working `unit_test` job). The compiler no longer changes mid-configure, so the `-D` backend flags stick.

**Gate unnecessary runs**
- `paths-ignore` (`**.md`, `documentation/**`, `docs/**`, `LICENSE`, `.gitignore`) on `miner_linux.yml` and `unit_test_linux.yml` — docs-only PRs no longer trigger the build/test.
- `concurrency` group that cancels in-progress runs for the same PR (`cancel-in-progress` only for `pull_request`, so push-to-main and release runs always finish).

**Speed up CUDA CI**
- On PR/push run only `build-miner-all` (it already compiles AMD+NVIDIA+CPU); the per-backend `amd`/`nvidia` jobs are gated behind a new `full_build` input.
- Build a single CUDA arch on CI (`-DNVCC_ARCH_COMPUTE=89`) — runners have no GPU, so this is compile-only validation. Releases keep the full multi-arch fat binary via `full_build: true` (passed by `miner_release.yml`).
- Add `nvcc -t0` to parallelize per-arch device codegen on the multi-arch release build (no-op for single-arch CI).

## Behavior

| Trigger | Jobs | CUDA archs |
|---|---|---|
| PR / push to main | `all` only | 1 (sm_89) |
| `workflow_dispatch` (default) | `all` only | 1 |
| `workflow_dispatch` (`full_build` ✓) | amd + nvidia + all | all |
| Release (`miner_release`) | amd + nvidia + all | all (+`-t0`) |

Net: a PR goes from 3 × full-arch builds to a single single-arch `all` build, while release artifacts keep full GPU coverage.

## Validation

- All workflows parse cleanly (`js-yaml`); `git diff --check` clean.
- New `full_build` input follows the existing input style in `boost_linux.yml`.
- This PR touches CI + CMake (not docs-only), so it exercises the new fast `all` single-arch path as a self-test.

## Trade-off / note

Single-arch CI won't catch a compile error that only triggers on sm_90+/Blackwell archs — it would surface at release or via a manual `workflow_dispatch` with `full_build` enabled. If `Linux Miner` / `Linux Unit Tests` are *required* status checks, confirm branch protection tolerates skipped runs on docs-only PRs.
