### PR TITLE
fix(cmake): honor OPENSSL_WIN_ROOT in vcpkg openssl module

### DIFF
--- a/cmake/deps/vcpkg/openssl.cmake
+++ b/cmake/deps/vcpkg/openssl.cmake
@@ -1,4 +1,23 @@
 set(OPENSSL_USE_STATIC_LIBS TRUE)
 set(OPEN_SSL_LIBRARIES OpenSSL::SSL OpenSSL::Crypto)
-set(LM_WIN_CROSS OFF)
-find_package(OpenSSL REQUIRED COMPONENTS SSL Crypto)
+
+# LM_WIN_CROSS: presence of OPENSSL_WIN_ROOT means prebuilt MSVC OpenSSL libs are
+# staged by the Docker windows-cross image. That preset resolves Boost via vcpkg
+# (USE_VCPKG=ON) but cannot cross-build OpenSSL to windows-msvc from Linux, so
+# OpenSSL is supplied out-of-band and must be wired up by hand here -- a plain
+# find_package would not see it. Fall back to vcpkg-resolved OpenSSL otherwise.
+if (DEFINED ENV{OPENSSL_WIN_ROOT})
+    set(LM_WIN_CROSS ON)
+    set(_ssl "$ENV{OPENSSL_WIN_ROOT}")
+    add_library(OpenSSL::Crypto STATIC IMPORTED)
+    add_library(OpenSSL::SSL    STATIC IMPORTED)
+    set_target_properties(OpenSSL::Crypto PROPERTIES
+        IMPORTED_LOCATION "${_ssl}/lib/libcrypto.lib"
+        INTERFACE_INCLUDE_DIRECTORIES "${_ssl}/include")
+    set_target_properties(OpenSSL::SSL PROPERTIES
+        IMPORTED_LOCATION "${_ssl}/lib/libssl.lib"
+        INTERFACE_INCLUDE_DIRECTORIES "${_ssl}/include")
+else()
+    set(LM_WIN_CROSS OFF)
+    find_package(OpenSSL REQUIRED COMPONENTS SSL Crypto)
+endif()


### PR DESCRIPTION
### Problem

After #177 (`cmake_split`), the `docker/Dockerfile.windows-cross` build fails at configure with:

```
CMake Error: Could NOT find OpenSSL (missing: OPENSSL_CRYPTO_LIBRARY OPENSSL_INCLUDE_DIR SSL Crypto)
  cmake/deps/vcpkg/openssl.cmake:4 (find_package)
```

for `GPU=amd`, `nvidia`, and `both`.

### Root cause

The refactor moved the prebuilt-MSVC-OpenSSL imported-target logic into `cmake/deps/system/openssl.cmake` **only**. But the `windows-cross` preset sets `USE_VCPKG=ON` (vcpkg is required to cross-build Boost), so the root `CMakeLists.txt` routes OpenSSL through `cmake/deps/vcpkg/openssl.cmake` instead. That module was a bare `find_package(OpenSSL REQUIRED)`.

That preset deliberately installs **only Boost** from vcpkg (`VCPKG_MANIFEST_FEATURES=""`) and supplies OpenSSL out-of-band as prebuilt MSVC import libs via `OPENSSL_WIN_ROOT` (vcpkg can't cross-build OpenSSL to windows-msvc from Linux). `find_package` never saw it, so configure aborted.

### Fix

Teach `cmake/deps/vcpkg/openssl.cmake` to honor `OPENSSL_WIN_ROOT` first (mirroring `system/openssl.cmake`), falling back to vcpkg-resolved `find_package` otherwise. One file.

### Verification

- Reproduced the failure on unpatched `main` (`GPU=amd`).
- Patched build `GPU=amd` → configure passes, 170 targets compile + link, ships `miner.exe` (PE32+) + OpenSSL DLLs, runs `--help` natively.
- Native (system) and `linux` / `linux-cpu` / `macos-cpu` presets unaffected (they pass `openssl` in `VCPKG_MANIFEST_FEATURES`, so the `find_package` fallback path is unchanged).
