### PR TITLE
fix(blake3): drop cast.hpp from vendored blake3.c (#181)

### DIFF
--- a/sources/algo/blake3/cpu/blake3.c
+++ b/sources/algo/blake3/cpu/blake3.c
@@ -190,7 +190,8 @@ INLINE size_t compress_chunks_parallel(const uint8_t *input, size_t input_len,
 
   blake3_hash_many(chunks_array, chunks_array_len,
                    BLAKE3_CHUNK_LEN / BLAKE3_BLOCK_LEN, key, chunk_counter,
-                   true, flags, static_cast<uint8_t>(Blake3Flags::CHUNK_START), static_cast<uint8_t>(Blake3Flags::CHUNK_END), out);
+                   true, flags, static_cast<uint8_t>(Blake3Flags::CHUNK_START),
+                   static_cast<uint8_t>(Blake3Flags::CHUNK_END), out);
 
   // Hash the remaining partial chunk, if there is one. Note that the empty
   // chunk (meaning the empty message) is a different codepath.

--- a/sources/algo/blake3/cpu/blake3.c
+++ b/sources/algo/blake3/cpu/blake3.c
@@ -4,7 +4,6 @@
 
 #include "blake3.h"
 #include "blake3_impl.h"
-#include "common/cast.hpp"
 #include "blake3_dispatch.c"
 #include "blake3_portable.c"
 #if BLAKE3_USE_NEON == 1
@@ -51,7 +50,7 @@ INLINE size_t chunk_state_fill_buf(blake3_chunk_state *self,
 
 INLINE uint8_t chunk_state_maybe_start_flag(const blake3_chunk_state *self) {
   if (self->blocks_compressed == 0) {
-    return castU8(Blake3Flags::CHUNK_START);
+    return static_cast<uint8_t>(Blake3Flags::CHUNK_START);
   } else {
     return 0;
   }
@@ -99,7 +98,7 @@ INLINE void output_root_bytes(const output_t *self, uint64_t seek, uint8_t *out,
   uint8_t wide_buf[64];
   while (out_len > 0) {
     blake3_compress_xof(self->input_cv, self->block, self->block_len,
-                        output_block_counter, self->flags | castU8(Blake3Flags::ROOT), wide_buf);
+                        output_block_counter, self->flags | static_cast<uint8_t>(Blake3Flags::ROOT), wide_buf);
     size_t available_bytes = 64 - offset_within_block;
     size_t memcpy_len;
     if (out_len > available_bytes) {
@@ -147,14 +146,14 @@ INLINE void chunk_state_update(blake3_chunk_state *self, const uint8_t *input,
 
 INLINE output_t chunk_state_output(const blake3_chunk_state *self) {
   uint8_t block_flags =
-      self->flags | chunk_state_maybe_start_flag(self) | castU8(Blake3Flags::CHUNK_END);
+      self->flags | chunk_state_maybe_start_flag(self) | static_cast<uint8_t>(Blake3Flags::CHUNK_END);
   return make_output(self->cv, self->buf, self->buf_len, self->chunk_counter,
                      block_flags);
 }
 
 INLINE output_t parent_output(const uint8_t block[BLAKE3_BLOCK_LEN],
                               const uint32_t key[8], uint8_t flags) {
-  return make_output(key, block, BLAKE3_BLOCK_LEN, 0, flags | castU8(Blake3Flags::PARENT));
+  return make_output(key, block, BLAKE3_BLOCK_LEN, 0, flags | static_cast<uint8_t>(Blake3Flags::PARENT));
 }
 
 // Given some input larger than one chunk, return the number of bytes that
@@ -191,7 +190,7 @@ INLINE size_t compress_chunks_parallel(const uint8_t *input, size_t input_len,
 
   blake3_hash_many(chunks_array, chunks_array_len,
                    BLAKE3_CHUNK_LEN / BLAKE3_BLOCK_LEN, key, chunk_counter,
-                   true, flags, castU8(Blake3Flags::CHUNK_START), castU8(Blake3Flags::CHUNK_END), out);
+                   true, flags, static_cast<uint8_t>(Blake3Flags::CHUNK_START), static_cast<uint8_t>(Blake3Flags::CHUNK_END), out);
 
   // Hash the remaining partial chunk, if there is one. Note that the empty
   // chunk (meaning the empty message) is a different codepath.
@@ -234,7 +233,7 @@ INLINE size_t compress_parents_parallel(const uint8_t *child_chaining_values,
 
   blake3_hash_many(parents_array, parents_array_len, 1, key,
                    0, // Parents always use counter 0.
-                   false, flags | castU8(Blake3Flags::PARENT),
+                   false, flags | static_cast<uint8_t>(Blake3Flags::PARENT),
                    0, // Parents have no start flags.
                    0, // Parents have no end flags.
                    out);
@@ -378,19 +377,19 @@ void blake3_hasher_init_keyed(blake3_hasher *self,
                               const uint8_t key[BLAKE3_KEY_LEN]) {
   uint32_t key_words[8];
   load_key_words(key, key_words);
-  hasher_init_base(self, key_words, castU8(Blake3Flags::KEYED_HASH));
+  hasher_init_base(self, key_words, static_cast<uint8_t>(Blake3Flags::KEYED_HASH));
 }
 
 void blake3_hasher_init_derive_key_raw(blake3_hasher *self, const void *context,
                                        size_t context_len) {
   blake3_hasher context_hasher;
-  hasher_init_base(&context_hasher, IV, castU8(Blake3Flags::DERIVE_KEY_CONTEXT));
+  hasher_init_base(&context_hasher, IV, static_cast<uint8_t>(Blake3Flags::DERIVE_KEY_CONTEXT));
   blake3_hasher_update(&context_hasher, context, context_len);
   uint8_t context_key[BLAKE3_KEY_LEN];
   blake3_hasher_finalize(&context_hasher, context_key, BLAKE3_KEY_LEN);
   uint32_t context_key_words[8];
   load_key_words(context_key, context_key_words);
-  hasher_init_base(self, context_key_words, castU8(Blake3Flags::DERIVE_KEY_MATERIAL));
+  hasher_init_base(self, context_key_words, static_cast<uint8_t>(Blake3Flags::DERIVE_KEY_MATERIAL));
 }
 
 void blake3_hasher_init_derive_key(blake3_hasher *self, const char *context) {


### PR DESCRIPTION
Fixes #181.

## Problem

On `feat/pearl`, `blake3.c` fails to build:

```
sources/algo/blake3/cpu/blake3.c:5:10: fatal error: 'common/cast.hpp' file not found
#include <common/cast.hpp>
```

`blake3.c` is compiled into the standalone `blake3_ref` static library, and that target's only include directory is its own folder:

```cmake
target_include_directories(blake3_ref PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
```

The project root (`sources/`) is **not** on this target's include path, so `common/cast.hpp` cannot be resolved — by quotes or angle brackets.

## Fix

Revert the `use cast.hpp` change in `blake3.c` back to plain `static_cast<uint8_t>`:

- `blake3_ref` is already compiled as C++ (`project(blake3_ref CXX)`), so `static_cast` is valid and idiomatic here — the `castU8()` macro buys nothing.
- `cast.hpp` also transitively pulls in `<chrono>` and `<CL/opencl.hpp>` (under `AMD_ENABLE`) — dependencies the canonical BLAKE3 reference library shouldn't carry.
- No new dependency, no CMake include-path change. Single file touched.

## Verification

`blake3.c` compiles clean as C++ with only `cpu/` on the include path — the exact include config `blake3_ref` uses:

```sh
g++ -std=c++17 -c blake3.c -I.   # exit 0
```

(Full project configure unavailable in my environment — Boost 1.91 / OpenSSL not installed — so the translation unit was compiled in isolation against the real target include set.)