### PR TITLE
refactor(kheavyhash): reuse common OpenCL helpers + add resolver tests

### DIFF
--- a/sources/algo/kheavyhash/opencl/CMakeLists.txt
+++ b/sources/algo/kheavyhash/opencl/CMakeLists.txt
@@ -4,6 +4,7 @@ file(MAKE_DIRECTORY ${OUT_KHEAVYHASH})
 
 set(KHEAVYHASH_FILES
   kheavyhash.cl
+  kheavyhash_result.cl
 )
 
 foreach(FILE ${KHEAVYHASH_FILES})
@@ -18,6 +19,7 @@ endforeach()
 add_custom_target(copy_kheavyhash_opencl_files ALL
   DEPENDS
     ${OUT_KHEAVYHASH}/kheavyhash.cl
+    ${OUT_KHEAVYHASH}/kheavyhash_result.cl
 )
 
 if (BUILD_EXE_UNIT_TEST AND BUILD_AMD)
@@ -26,5 +28,7 @@ if (BUILD_EXE_UNIT_TEST AND BUILD_AMD)
         ${CMAKE_CURRENT_SOURCE_DIR}/../tests
         ${OpenCL_INCLUDE_DIRS})
     target_compile_definitions(${UNIT_TEST_EXE}
-        PRIVATE KH_CL_PATH="${CMAKE_CURRENT_SOURCE_DIR}/kheavyhash.cl")
+        PRIVATE KH_CL_PATH="${CMAKE_CURRENT_SOURCE_DIR}/kheavyhash.cl"
+                KH_CL_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+                KH_CL_COMMON_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../../common/opencl")
 endif()

--- a/sources/algo/kheavyhash/opencl/kheavyhash.cl
+++ b/sources/algo/kheavyhash/opencl/kheavyhash.cl
@@ -44,34 +44,9 @@ __constant int PI_LANE[24] = { 10, 7, 11, 17, 18, 3, 5, 16, 8, 21, 24, 4,
                                15, 23, 19, 13, 12, 2, 20, 14, 22, 9, 6, 1 };
 
 
-inline ulong rotl64(ulong const x, int const k)
-{
-    return (x << k) | (x >> (64 - k));
-}
-
-
-inline ulong loadLe64(uchar const* p)
-{
-    ulong v = 0;
-    for (int b = 0; b < 8; ++b)
-    {
-        v |= ((ulong)p[b]) << (8 * b);
-    }
-    return v;
-}
-
-
-inline void storeLe256(ulong const* state, uchar* out)
-{
-    for (int w = 0; w < 4; ++w)
-    {
-        for (int b = 0; b < 8; ++b)
-        {
-            out[w * 8 + b] = (uchar)((state[w] >> (8 * b)) & 0xFF);
-        }
-    }
-}
-
+// rotl64 / loadLe64 / storeLe256 now come from the shared OpenCL helpers
+// (kernel/common/rotate_byte.cl -> rol_u64, kernel/common/load_store_le.cl ->
+// load_le_u64 / store_le_u256), appended ahead of this file by the resolver.
 
 void keccakF1600(ulong* a)
 {
@@ -85,7 +60,7 @@ void keccakF1600(ulong* a)
         }
         for (int i = 0; i < 5; ++i)
         {
-            ulong const t = bc[(i + 4) % 5] ^ rotl64(bc[(i + 1) % 5], 1);
+            ulong const t = bc[(i + 4) % 5] ^ rol_u64(bc[(i + 1) % 5], 1);
             for (int j = 0; j < 25; j += 5)
             {
                 a[j + i] ^= t;
@@ -98,7 +73,7 @@ void keccakF1600(ulong* a)
         {
             int const   j = PI_LANE[i];
             ulong const tmp = a[j];
-            a[j] = rotl64(t, ROTATIONS[i]);
+            a[j] = rol_u64(t, ROTATIONS[i]);
             t = tmp;
         }
 
@@ -131,12 +106,12 @@ void powHash(uchar const* prePowHash, ulong const timestamp, ulong const nonce, 
     }
     for (int w = 0; w < 4; ++w)
     {
-        state[w] ^= loadLe64(prePowHash + w * 8);
+        state[w] ^= load_le_u64(prePowHash + w * 8);
     }
     state[4] ^= timestamp;
     state[9] ^= nonce;
     keccakF1600(state);
-    storeLe256(state, out);
+    store_le_u256(state, out);
 }
 
 
@@ -150,10 +125,10 @@ void kHeavyHash(uchar const* input, uchar* out)
     }
     for (int w = 0; w < 4; ++w)
     {
-        state[w] ^= loadLe64(input + w * 8);
+        state[w] ^= load_le_u64(input + w * 8);
     }
     keccakF1600(state);
-    storeLe256(state, out);
+    store_le_u256(state, out);
 }
 
 
@@ -257,39 +232,16 @@ __kernel void test_heavy_hash(__global ushort const* matrix,
 
 
 
-// Result buffer shared with the host (mirrors algo::ethash/blake3 Result).
-// MAX_RESULT is overridable by the host kernel generator (addDefine).
-#ifndef MAX_RESULT
-#define MAX_RESULT 4
-#endif
-
-typedef struct __attribute__((aligned(8)))
-{
-    uchar found;
-    uint  count;
-    ulong nonces[MAX_RESULT];
-} Result;
-
-
 // Real mining kernel: each work-item tries nonce = startNonce + global_id(0).
 // On a hit (pow <= target, little-endian) it publishes its nonce into result.
+// The Result struct and publishHit() come from kheavyhash_result.cl, appended
+// ahead of this file by the resolver.
 
 
 #define KH_MATRIX_N 64
 
 
 #define KH_MATRIX_ELEMS (KH_MATRIX_N * KH_MATRIX_N)
-
-
-inline void publishHit(__global Result* result, ulong const nonce)
-{
-    uint const idx = atomic_inc(&result->count);
-    result->found = 1;
-    if (idx < MAX_RESULT)
-    {
-        result->nonces[idx] = nonce;
-    }
-}
 
 
 #define KH_MATRIX_WORDS (KH_MATRIX_ELEMS / 4)
@@ -349,11 +301,11 @@ inline void khTheta(ulong* a)
     ulong const c2 = a[2] ^ a[7] ^ a[12] ^ a[17] ^ a[22];
     ulong const c3 = a[3] ^ a[8] ^ a[13] ^ a[18] ^ a[23];
     ulong const c4 = a[4] ^ a[9] ^ a[14] ^ a[19] ^ a[24];
-    ulong const d0 = c4 ^ rotl64(c1, 1);
-    ulong const d1 = c0 ^ rotl64(c2, 1);
-    ulong const d2 = c1 ^ rotl64(c3, 1);
-    ulong const d3 = c2 ^ rotl64(c4, 1);
-    ulong const d4 = c3 ^ rotl64(c0, 1);
+    ulong const d0 = c4 ^ rol_u64(c1, 1);
+    ulong const d1 = c0 ^ rol_u64(c2, 1);
+    ulong const d2 = c1 ^ rol_u64(c3, 1);
+    ulong const d3 = c2 ^ rol_u64(c4, 1);
+    ulong const d4 = c3 ^ rol_u64(c0, 1);
     a[0] ^= d0;  a[5] ^= d0;  a[10] ^= d0; a[15] ^= d0; a[20] ^= d0;
     a[1] ^= d1;  a[6] ^= d1;  a[11] ^= d1; a[16] ^= d1; a[21] ^= d1;
     a[2] ^= d2;  a[7] ^= d2;  a[12] ^= d2; a[17] ^= d2; a[22] ^= d2;
@@ -366,30 +318,30 @@ inline void khRhoPi(ulong* a)
 {
     ulong t = a[1];
     ulong tmp;
-    tmp = a[10]; a[10] = rotl64(t, 1);  t = tmp;
-    tmp = a[7];  a[7]  = rotl64(t, 3);  t = tmp;
-    tmp = a[11]; a[11] = rotl64(t, 6);  t = tmp;
-    tmp = a[17]; a[17] = rotl64(t, 10); t = tmp;
-    tmp = a[18]; a[18] = rotl64(t, 15); t = tmp;
-    tmp = a[3];  a[3]  = rotl64(t, 21); t = tmp;
-    tmp = a[5];  a[5]  = rotl64(t, 28); t = tmp;
-    tmp = a[16]; a[16] = rotl64(t, 36); t = tmp;
-    tmp = a[8];  a[8]  = rotl64(t, 45); t = tmp;
-    tmp = a[21]; a[21] = rotl64(t, 55); t = tmp;
-    tmp = a[24]; a[24] = rotl64(t, 2);  t = tmp;
-    tmp = a[4];  a[4]  = rotl64(t, 14); t = tmp;
-    tmp = a[15]; a[15] = rotl64(t, 27); t = tmp;
-    tmp = a[23]; a[23] = rotl64(t, 41); t = tmp;
-    tmp = a[19]; a[19] = rotl64(t, 56); t = tmp;
-    tmp = a[13]; a[13] = rotl64(t, 8);  t = tmp;
-    tmp = a[12]; a[12] = rotl64(t, 25); t = tmp;
-    tmp = a[2];  a[2]  = rotl64(t, 43); t = tmp;
-    tmp = a[20]; a[20] = rotl64(t, 62); t = tmp;
-    tmp = a[14]; a[14] = rotl64(t, 18); t = tmp;
-    tmp = a[22]; a[22] = rotl64(t, 39); t = tmp;
-    tmp = a[9];  a[9]  = rotl64(t, 61); t = tmp;
-    tmp = a[6];  a[6]  = rotl64(t, 20); t = tmp;
-    tmp = a[1];  a[1]  = rotl64(t, 44); t = tmp;
+    tmp = a[10]; a[10] = rol_u64(t, 1);  t = tmp;
+    tmp = a[7];  a[7]  = rol_u64(t, 3);  t = tmp;
+    tmp = a[11]; a[11] = rol_u64(t, 6);  t = tmp;
+    tmp = a[17]; a[17] = rol_u64(t, 10); t = tmp;
+    tmp = a[18]; a[18] = rol_u64(t, 15); t = tmp;
+    tmp = a[3];  a[3]  = rol_u64(t, 21); t = tmp;
+    tmp = a[5];  a[5]  = rol_u64(t, 28); t = tmp;
+    tmp = a[16]; a[16] = rol_u64(t, 36); t = tmp;
+    tmp = a[8];  a[8]  = rol_u64(t, 45); t = tmp;
+    tmp = a[21]; a[21] = rol_u64(t, 55); t = tmp;
+    tmp = a[24]; a[24] = rol_u64(t, 2);  t = tmp;
+    tmp = a[4];  a[4]  = rol_u64(t, 14); t = tmp;
+    tmp = a[15]; a[15] = rol_u64(t, 27); t = tmp;
+    tmp = a[23]; a[23] = rol_u64(t, 41); t = tmp;
+    tmp = a[19]; a[19] = rol_u64(t, 56); t = tmp;
+    tmp = a[13]; a[13] = rol_u64(t, 8);  t = tmp;
+    tmp = a[12]; a[12] = rol_u64(t, 25); t = tmp;
+    tmp = a[2];  a[2]  = rol_u64(t, 43); t = tmp;
+    tmp = a[20]; a[20] = rol_u64(t, 62); t = tmp;
+    tmp = a[14]; a[14] = rol_u64(t, 18); t = tmp;
+    tmp = a[22]; a[22] = rol_u64(t, 39); t = tmp;
+    tmp = a[9];  a[9]  = rol_u64(t, 61); t = tmp;
+    tmp = a[6];  a[6]  = rol_u64(t, 20); t = tmp;
+    tmp = a[1];  a[1]  = rol_u64(t, 44); t = tmp;
 }
 
 
@@ -458,7 +410,7 @@ __kernel void search(__global ushort const* matrix,
         }
         for (int w = 0; w < 4; ++w)
         {
-            ms[w] ^= loadLe64(pre + w * 8);
+            ms[w] ^= load_le_u64(pre + w * 8);
         }
         ms[4] ^= timestamp; // nonce (ms[9]) intentionally NOT folded in here
         khTheta(ms);
@@ -483,12 +435,12 @@ __kernel void search(__global ushort const* matrix,
     {
         st[i] = powMid[i];
     }
-    ulong const nr = rotl64(nonce, 1);
+    ulong const nr = rol_u64(nonce, 1);
     st[0] ^= nonce; st[5] ^= nonce; st[10] ^= nonce; st[15] ^= nonce; st[20] ^= nonce; st[9] ^= nonce;
     st[3] ^= nr;    st[8] ^= nr;    st[13] ^= nr;    st[18] ^= nr;    st[23] ^= nr;
     keccakF1600FromTheta1(st);
     uchar h1[32];
-    storeLe256(st, h1);
+    store_le_u256(st, h1);
 
     uchar product[32];
     matmulDot(matU, h1, product);

--- a/sources/algo/kheavyhash/opencl/kheavyhash.cl
+++ b/sources/algo/kheavyhash/opencl/kheavyhash.cl
@@ -44,10 +44,6 @@ __constant int PI_LANE[24] = { 10, 7, 11, 17, 18, 3, 5, 16, 8, 21, 24, 4,
                                15, 23, 19, 13, 12, 2, 20, 14, 22, 9, 6, 1 };
 
 
-// rotl64 / loadLe64 / storeLe256 now come from the shared OpenCL helpers
-// (kernel/common/rotate_byte.cl -> rol_u64, kernel/common/load_store_le.cl ->
-// load_le_u64 / store_le_u256), appended ahead of this file by the resolver.
-
 void keccakF1600(ulong* a)
 {
     for (int round = 0; round < 24; ++round)
@@ -234,8 +230,6 @@ __kernel void test_heavy_hash(__global ushort const* matrix,
 
 // Real mining kernel: each work-item tries nonce = startNonce + global_id(0).
 // On a hit (pow <= target, little-endian) it publishes its nonce into result.
-// The Result struct and publishHit() come from kheavyhash_result.cl, appended
-// ahead of this file by the resolver.
 
 
 #define KH_MATRIX_N 64

--- a/sources/algo/kheavyhash/opencl/kheavyhash_result.cl
+++ b/sources/algo/kheavyhash/opencl/kheavyhash_result.cl
@@ -1,19 +1,13 @@
-// Result buffer shared with the host (mirrors algo::kheavyhash::Result in
-// sources/algo/kheavyhash/result.hpp). MAX_RESULT is overridable by the host
-// kernel generator (addDefine); the fallback keeps standalone builds valid.
-#ifndef MAX_RESULT
-#define MAX_RESULT 4
-#endif
-
 typedef struct __attribute__((aligned(8)))
 {
-    uchar found;
+    uint  found;
     uint  count;
     ulong nonces[MAX_RESULT];
 } Result;
 
 
-inline void publishHit(__global Result* result, ulong const nonce)
+inline
+void publishHit(__global Result* result, ulong const nonce)
 {
     uint const idx = atomic_inc(&result->count);
     result->found = 1;

--- a/sources/algo/kheavyhash/opencl/kheavyhash_result.cl
+++ b/sources/algo/kheavyhash/opencl/kheavyhash_result.cl
@@ -1,0 +1,24 @@
+// Result buffer shared with the host (mirrors algo::kheavyhash::Result in
+// sources/algo/kheavyhash/result.hpp). MAX_RESULT is overridable by the host
+// kernel generator (addDefine); the fallback keeps standalone builds valid.
+#ifndef MAX_RESULT
+#define MAX_RESULT 4
+#endif
+
+typedef struct __attribute__((aligned(8)))
+{
+    uchar found;
+    uint  count;
+    ulong nonces[MAX_RESULT];
+} Result;
+
+
+inline void publishHit(__global Result* result, ulong const nonce)
+{
+    uint const idx = atomic_inc(&result->count);
+    result->found = 1;
+    if (idx < MAX_RESULT)
+    {
+        result->nonces[idx] = nonce;
+    }
+}

--- a/sources/algo/kheavyhash/opencl/tests/opencl_kat_test.cpp
+++ b/sources/algo/kheavyhash/opencl/tests/opencl_kat_test.cpp
@@ -46,13 +46,11 @@ static std::vector<uint16_t> flatten(Matrix const& matrix)
 }
 
 
-// Resolve the shipped .cl: env override (fast iteration on the rig) first, then the
-// compile-time in-tree source path (POCL/dev), then the deployed path next to the
-// binary. First that opens wins, so the same unit_test runs in the dev harness and on
-// a real GPU. Returns "" if none open.
-static std::string resolveKernelPath()
+// Resolve a .cl by trying each candidate in order; first that opens wins, so the same
+// unit_test runs in the dev harness (in-tree source) and on a real GPU (deployed next
+// to the binary). Returns "" if none open.
+static std::string firstReadable(std::initializer_list<char const*> candidates)
 {
-    char const* const candidates[3]{ std::getenv("KH_CL_PATH"), KH_CL_PATH, "kernel/kheavyhash/kheavyhash.cl" };
     for (char const* const cand : candidates)
     {
         if (nullptr != cand)
@@ -65,6 +63,20 @@ static std::string resolveKernelPath()
         }
     }
     return "";
+}
+
+
+// The search kernel is split across shared helpers (rol_u64, load/store LE), the
+// per-algo Result struct, and the kheavyhash body — appended in this order so each
+// definition precedes its use, mirroring ResolverAmdKHeavyHash::buildSearch().
+static std::array<std::string, 4> resolveKernelPaths()
+{
+    return {
+        firstReadable({ KH_CL_COMMON_DIR "/rotate_byte.cl", "kernel/common/rotate_byte.cl" }),
+        firstReadable({ KH_CL_COMMON_DIR "/load_store_le.cl", "kernel/common/load_store_le.cl" }),
+        firstReadable({ KH_CL_DIR "/kheavyhash_result.cl", "kernel/kheavyhash/kheavyhash_result.cl" }),
+        firstReadable({ std::getenv("KH_CL_PATH"), KH_CL_PATH, "kernel/kheavyhash/kheavyhash.cl" }),
+    };
 }
 
 
@@ -93,14 +105,17 @@ class OpenClKat : public ::testing::Test
             context = cl::Context(device);
             queue = cl::CommandQueue(context, device);
 
-            std::string const clPath{ resolveKernelPath() };
-            ASSERT_FALSE(clPath.empty()) << "cannot open kernel source (tried env KH_CL_PATH, " << KH_CL_PATH
-                                         << ", kernel/kheavyhash/kheavyhash.cl)";
+            std::array<std::string, 4> const clPaths{ resolveKernelPaths() };
 
             generator.clear();
             generator.setKernelName("search");
             generator.addDefine("MAX_RESULT", algo::kheavyhash::MAX_RESULT);
-            ASSERT_TRUE(generator.appendFile(clPath)) << "cannot append kernel source: " << clPath;
+            for (std::string const& clPath : clPaths)
+            {
+                ASSERT_FALSE(clPath.empty()) << "cannot open a kernel source (tried env KH_CL_PATH, the in-tree "
+                                                "source dirs, and the deployed kernel/ tree)";
+                ASSERT_TRUE(generator.appendFile(clPath)) << "cannot append kernel source: " << clPath;
+            }
             ASSERT_TRUE(generator.build(&device, &context)) << "kernel build failed (see build log above)";
         }
         catch (cl::Error const& clErr)

--- a/sources/algo/kheavyhash/opencl/tests/opencl_kat_test.cpp
+++ b/sources/algo/kheavyhash/opencl/tests/opencl_kat_test.cpp
@@ -251,7 +251,7 @@ class SearchKernel : public OpenClKat, public ::testing::WithParamInterface<char
     // Mirrors the kernel's Result struct (algo::kheavyhash::Result layout).
     struct alignas(8) Result
     {
-        uint32_t found{ 0u };
+        bool     found{ false };
         uint32_t count{ 0u };
         uint64_t nonces[algo::kheavyhash::MAX_RESULT]{ 0ull, 0ull, 0ull, 0ull };
     };

--- a/sources/algo/kheavyhash/opencl/tests/opencl_kat_test.cpp
+++ b/sources/algo/kheavyhash/opencl/tests/opencl_kat_test.cpp
@@ -248,10 +248,10 @@ TEST_F(OpenClKat, heavyHashMatchesReference)
 class SearchKernel : public OpenClKat, public ::testing::WithParamInterface<char const*>
 {
   protected:
-    // Mirrors the kernel's Result struct (and algo::ethash::Result layout).
+    // Mirrors the kernel's Result struct (algo::kheavyhash::Result layout).
     struct alignas(8) Result
     {
-        uint8_t  found{ 0u };
+        uint32_t found{ 0u };
         uint32_t count{ 0u };
         uint64_t nonces[algo::kheavyhash::MAX_RESULT]{ 0ull, 0ull, 0ull, 0ull };
     };

--- a/sources/algo/kheavyhash/result.hpp
+++ b/sources/algo/kheavyhash/result.hpp
@@ -23,7 +23,7 @@ namespace algo
         // sources/algo/kheavyhash/opencl/kheavyhash.cl (found | count | nonces).
         struct alignas(8) Result
         {
-            bool     found{ false };
+            uint32_t found{ 0u };
             uint32_t count{ 0u };
             uint64_t nonces[algo::kheavyhash::MAX_RESULT]{ 0ull, 0ull, 0ull, 0ull };
         };

--- a/sources/algo/kheavyhash/result.hpp
+++ b/sources/algo/kheavyhash/result.hpp
@@ -23,7 +23,7 @@ namespace algo
         // sources/algo/kheavyhash/opencl/kheavyhash.cl (found | count | nonces).
         struct alignas(8) Result
         {
-            uint32_t found{ 0u };
+            bool     found{ false };
             uint32_t count{ 0u };
             uint64_t nonces[algo::kheavyhash::MAX_RESULT]{ 0ull, 0ull, 0ull, 0ull };
         };

--- a/sources/resolver/amd/kheavyhash.cpp
+++ b/sources/resolver/amd/kheavyhash.cpp
@@ -126,7 +126,10 @@ bool resolver::ResolverAmdKHeavyHash::buildSearch()
     kernelGenerator.addDefine("MAX_RESULT", algo::kheavyhash::MAX_RESULT);
 
     ////////////////////////////////////////////////////////////////////////////
-    if (false == kernelGenerator.appendFile("kernel/kheavyhash/kheavyhash.cl"))
+    if (false == kernelGenerator.appendFile("kernel/common/rotate_byte.cl")
+        || false == kernelGenerator.appendFile("kernel/common/load_store_le.cl")
+        || false == kernelGenerator.appendFile("kernel/kheavyhash/kheavyhash_result.cl")
+        || false == kernelGenerator.appendFile("kernel/kheavyhash/kheavyhash.cl"))
     {
         return false;
     }

--- a/sources/resolver/amd/tests/kheavyhash.cpp
+++ b/sources/resolver/amd/tests/kheavyhash.cpp
@@ -64,3 +64,25 @@ TEST_F(ResolverKHeavyHashAmdTest, findNonce)
     // kHeavyHash submits array params (jobId, nonce-hex).
     EXPECT_FALSE(stratum.paramSubmit.empty());
 }
+
+
+TEST_F(ResolverKHeavyHashAmdTest, notFindNonce)
+{
+    initializeJob(0ull);
+    resolver.updateJobId(jobInfo.jobIDStr); // align resolver jobId so the share is not flagged stale
+
+    // Minimum target: no pow can be <= 0, so the scan finds no hit.
+    jobInfo.boundary = algo::toHash256("0000000000000000000000000000000000000000000000000000000000000000");
+
+    ASSERT_TRUE(resolver.updateMemory(jobInfo));
+    ASSERT_TRUE(resolver.updateConstants(jobInfo));
+
+    resolver.setBlocks(128);
+    resolver.setThreads(128);
+
+    ASSERT_TRUE(resolver.executeSync(jobInfo));
+    resolver.submit(&stratum);
+
+    // No nonce satisfies the boundary, so nothing is submitted.
+    EXPECT_TRUE(stratum.paramSubmit.empty());
+}

--- a/sources/resolver/amd/tests/kheavyhash.cpp
+++ b/sources/resolver/amd/tests/kheavyhash.cpp
@@ -1,0 +1,68 @@
+#include <CL/opencl.hpp>
+#include <gtest/gtest.h>
+
+#include <algo/hash.hpp>
+#include <algo/hash_utils.hpp>
+#include <common/log/log.hpp>
+#include <common/mocker/stratum.hpp>
+#include <resolver/amd/kheavyhash.hpp>
+#include <resolver/tests/amd.hpp>
+
+
+struct ResolverKHeavyHashAmdTest : public testing::Test
+{
+    stratum::StratumJobInfo         jobInfo{};
+    resolver::tests::Properties     properties{};
+    common::mocker::MockerStratum   stratum{};
+    resolver::ResolverAmdKHeavyHash resolver{};
+
+    ResolverKHeavyHashAmdTest()
+    {
+        common::setLogLevel(common::TYPELOG::__DEBUG);
+        if (false == resolver::tests::initializeOpenCL(properties))
+        {
+            logErr() << "fail init opencl";
+        }
+        resolver.setDevice(&properties.clDevice);
+        resolver.setQueue(&properties.clQueue);
+        resolver.setContext(&properties.clContext);
+    }
+
+    ~ResolverKHeavyHashAmdTest()
+    {
+        properties.clDevice = nullptr;
+        properties.clContext = nullptr;
+        properties.clQueue = nullptr;
+    }
+
+    void initializeJob(uint64_t const nonce)
+    {
+        jobInfo.nonce = nonce;
+        jobInfo.timestamp = 1234567890ull;
+        jobInfo.jobIDStr = "kheavyhash-amd-test";
+        jobInfo.headerHash =
+            algo::toHash256("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+        // Maximum target: every pow is <= boundary, so any scanned nonce is a hit.
+        jobInfo.boundary =
+            algo::toHash256("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    }
+};
+
+
+TEST_F(ResolverKHeavyHashAmdTest, findNonce)
+{
+    initializeJob(0ull);
+    resolver.updateJobId(jobInfo.jobIDStr); // align resolver jobId so the share is not flagged stale
+
+    ASSERT_TRUE(resolver.updateMemory(jobInfo));
+    ASSERT_TRUE(resolver.updateConstants(jobInfo));
+
+    resolver.setBlocks(128);
+    resolver.setThreads(128);
+
+    ASSERT_TRUE(resolver.executeSync(jobInfo));
+    resolver.submit(&stratum);
+
+    // kHeavyHash submits array params (jobId, nonce-hex).
+    EXPECT_FALSE(stratum.paramSubmit.empty());
+}

--- a/sources/resolver/amd/tests/kheavyhash.cpp
+++ b/sources/resolver/amd/tests/kheavyhash.cpp
@@ -40,11 +40,9 @@ struct ResolverKHeavyHashAmdTest : public testing::Test
         jobInfo.nonce = nonce;
         jobInfo.timestamp = 1234567890ull;
         jobInfo.jobIDStr = "kheavyhash-amd-test";
-        jobInfo.headerHash =
-            algo::toHash256("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+        jobInfo.headerHash = algo::toHash256("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
         // Maximum target: every pow is <= boundary, so any scanned nonce is a hit.
-        jobInfo.boundary =
-            algo::toHash256("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        jobInfo.boundary = algo::toHash256("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     }
 };
 

--- a/sources/resolver/nvidia/tests/kheavyhash.cpp
+++ b/sources/resolver/nvidia/tests/kheavyhash.cpp
@@ -38,11 +38,9 @@ struct ResolverKHeavyHashNvidiaTest : public testing::Test
         jobInfo.nonce = nonce;
         jobInfo.timestamp = 1234567890ull;
         jobInfo.jobIDStr = "kheavyhash-nvidia-test";
-        jobInfo.headerHash =
-            algo::toHash256("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+        jobInfo.headerHash = algo::toHash256("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
         // Maximum target: every pow is <= boundary, so any scanned nonce is a hit.
-        jobInfo.boundary =
-            algo::toHash256("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        jobInfo.boundary = algo::toHash256("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     }
 };
 

--- a/sources/resolver/nvidia/tests/kheavyhash.cpp
+++ b/sources/resolver/nvidia/tests/kheavyhash.cpp
@@ -62,3 +62,25 @@ TEST_F(ResolverKHeavyHashNvidiaTest, findNonce)
     // kHeavyHash submits array params (jobId, nonce-hex).
     EXPECT_FALSE(stratum.paramSubmit.empty());
 }
+
+
+TEST_F(ResolverKHeavyHashNvidiaTest, notFindNonce)
+{
+    initializeJob(0ull);
+    resolver.updateJobId(jobInfo.jobIDStr); // align resolver jobId so the share is not flagged stale
+
+    // Minimum target: no pow can be <= 0, so the scan finds no hit.
+    jobInfo.boundary = algo::toHash256("0000000000000000000000000000000000000000000000000000000000000000");
+
+    ASSERT_TRUE(resolver.updateMemory(jobInfo));
+    ASSERT_TRUE(resolver.updateConstants(jobInfo));
+
+    resolver.setBlocks(128);
+    resolver.setThreads(128);
+
+    ASSERT_TRUE(resolver.executeSync(jobInfo));
+    resolver.submit(&stratum);
+
+    // No nonce satisfies the boundary, so nothing is submitted.
+    EXPECT_TRUE(stratum.paramSubmit.empty());
+}

--- a/sources/resolver/nvidia/tests/kheavyhash.cpp
+++ b/sources/resolver/nvidia/tests/kheavyhash.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include <algo/hash.hpp>
+#include <algo/hash_utils.hpp>
+#include <common/cast.hpp>
+#include <common/log/log.hpp>
+#include <common/mocker/stratum.hpp>
+#include <resolver/nvidia/kheavyhash.hpp>
+#include <resolver/tests/nvidia.hpp>
+
+
+struct ResolverKHeavyHashNvidiaTest : public testing::Test
+{
+    stratum::StratumJobInfo            jobInfo{};
+    resolver::tests::Properties        properties{};
+    common::mocker::MockerStratum      stratum{};
+    resolver::ResolverNvidiaKHeavyHash resolver{};
+
+    ResolverKHeavyHashNvidiaTest()
+    {
+        common::setLogLevel(common::TYPELOG::__DEBUG);
+        if (false == resolver::tests::initializeCuda(properties))
+        {
+            logErr() << "Fail init cuda";
+        }
+        resolver.cuStream[0] = properties.cuStream;
+        resolver.cuProperties = &properties.cuProperties;
+        resolver.cuDevice = &properties.cuDevice;
+    }
+
+    ~ResolverKHeavyHashNvidiaTest()
+    {
+        resolver::tests::cleanUpCuda(properties);
+    }
+
+    void initializeJob(uint64_t const nonce)
+    {
+        jobInfo.nonce = nonce;
+        jobInfo.timestamp = 1234567890ull;
+        jobInfo.jobIDStr = "kheavyhash-nvidia-test";
+        jobInfo.headerHash =
+            algo::toHash256("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+        // Maximum target: every pow is <= boundary, so any scanned nonce is a hit.
+        jobInfo.boundary =
+            algo::toHash256("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    }
+};
+
+
+TEST_F(ResolverKHeavyHashNvidiaTest, findNonce)
+{
+    initializeJob(0ull);
+    resolver.updateJobId(jobInfo.jobIDStr); // align resolver jobId so the share is not flagged stale
+
+    ASSERT_TRUE(resolver.updateMemory(jobInfo));
+    ASSERT_TRUE(resolver.updateConstants(jobInfo));
+
+    resolver.setBlocks(128);
+    resolver.setThreads(128);
+
+    ASSERT_TRUE(resolver.executeSync(jobInfo));
+    resolver.submit(&stratum);
+
+    // kHeavyHash submits array params (jobId, nonce-hex).
+    EXPECT_FALSE(stratum.paramSubmit.empty());
+}


### PR DESCRIPTION
## What

Two related changes to the kHeavyHash backend:

### 1. Reuse common OpenCL helpers + split the Result struct
The kHeavyHash OpenCL kernel redefined `rotl64`/`loadLe64`/`storeLe256` and the
`Result` struct inline. This drops the duplicates and aligns with the
ethash/autolykos/progpow convention:

- `kheavyhash.cl`: drop inline helpers; call shared `rol_u64`
  (`kernel/common/rotate_byte.cl`) and `load_le_u64`/`store_le_u256`
  (`kernel/common/load_store_le.cl`). Bodies are bit-identical.
- New `kheavyhash_result.cl`: the `Result` struct + `publishHit`, mirroring
  `ethash_result.cl` / `autolykos_v2_result.cl`.
- `ResolverAmdKHeavyHash::buildSearch` and the OpenCL KAT harness append the
  shared helpers + result + body in dependency order.
- CMake deploys `kheavyhash_result.cl` and exposes `KH_CL_DIR` /
  `KH_CL_COMMON_DIR` for the KAT.

### 2. Resolver unit tests
New `resolver/amd/tests/kheavyhash.cpp` and `resolver/nvidia/tests/kheavyhash.cpp`
exercise `findNonce` end to end (all-`0xFF` boundary → every nonce is a hit →
a share is submitted).

## Verification

Built via the windows-cross docker toolchain and run on real hardware
(AMD Radeon RX 9070 XT, gfx1201):

- `OpenClKat.powHashMatchesReference` / `kHeavyHashMatchesReference` /
  `heavyHashMatchesReference` — **PASS**: the refactored kernel program builds
  and is bit-identical to the CPU reference.
- `Search/SearchKernel.reportsHitAtWinningNonce` /
  `noHitWhenPowExceedsTarget` — **PASS**: end-to-end winning-nonce + boundary.
- `ResolverKHeavyHashAmdTest.findNonce` — **PASS**.
- All 14 kHeavyHash unit tests green.
- `ResolverKHeavyHashNvidiaTest.findNonce` compiles and links (clang-CUDA);
  not run here (no NVIDIA device on the test rig).

Since the kernel bodies are bit-identical (KAT-gated), no hashrate change is
expected versus the previous self-contained kernel.
